### PR TITLE
Correctly enable LTO

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -95,12 +95,13 @@ export LIBPATHS	:=	$(foreach dir,$(LIBDIRS),-L$(dir)/lib)
 #-------------------------------------------------------------------------------
 $(BUILD): $(CURDIR)/source/ios_kernel/ios_kernel.bin.h
 	@[ -d $@ ] || mkdir -p $@
+	@$(MAKE) -j1 --no-print-directory -C $(CURDIR)/source/ios_fs -f $(CURDIR)/source/ios_fs/Makefile
 	@$(MAKE) -j1 --no-print-directory -C $(CURDIR)/source/ios_mcp -f $(CURDIR)/source/ios_mcp/Makefile
 	@$(MAKE) -j1 --no-print-directory -C $(CURDIR)/source/ios_usb -f $(CURDIR)/source/ios_usb/Makefile    
 	@$(MAKE) -j1 --no-print-directory -C $(CURDIR)/source/ios_kernel -f $(CURDIR)/source/ios_kernel/Makefile
 	@$(MAKE) -j1 --no-print-directory -C $(BUILD) -f $(CURDIR)/Makefile
 
-$(CURDIR)/source/ios_kernel/ios_kernel.bin.h: $(CURDIR)/source/ios_usb/ios_usb.bin.h  $(CURDIR)/source/ios_mcp/ios_mcp.bin.h
+$(CURDIR)/source/ios_kernel/ios_kernel.bin.h: $(CURDIR)/source/ios_usb/ios_usb.bin.h  $(CURDIR)/source/ios_mcp/ios_mcp.bin.h $(CURDIR)/source/ios_fs/ios_fs.bin.h
 	@$(MAKE) -j1 --no-print-directory -C $(CURDIR)/source/ios_kernel -f $(CURDIR)/source/ios_kernel/Makefile
 
 $(CURDIR)/source/ios_usb/ios_usb.bin.h: 
@@ -108,6 +109,9 @@ $(CURDIR)/source/ios_usb/ios_usb.bin.h:
     
 $(CURDIR)/source/ios_mcp/ios_mcp.bin.h: 
 	@$(MAKE) -j1 --no-print-directory -C $(CURDIR)/source/ios_mcp -f $(CURDIR)/source/ios_mcp/Makefile
+
+$(CURDIR)/source/ios_fs/ios_fs.bin.h: 
+	@$(MAKE) -j1 --no-print-directory -C $(CURDIR)/source/ios_fs -f $(CURDIR)/source/ios_fs/Makefile
 #-------------------------------------------------------------------------------
 clean:
 	@echo clean ...
@@ -115,6 +119,7 @@ clean:
 	@$(MAKE) --no-print-directory -C $(CURDIR)/source/ios_kernel -f  $(CURDIR)/source/ios_kernel/Makefile clean
 	@$(MAKE) --no-print-directory -C $(CURDIR)/source/ios_usb -f  $(CURDIR)/source/ios_usb/Makefile clean
 	@$(MAKE) --no-print-directory -C $(CURDIR)/source/ios_mcp -f  $(CURDIR)/source/ios_mcp/Makefile clean	
+	@$(MAKE) --no-print-directory -C $(CURDIR)/source/ios_fs -f  $(CURDIR)/source/ios_fs/Makefile clean	
 
 #-------------------------------------------------------------------------------
 else

--- a/source/ios_exploit.c
+++ b/source/ios_exploit.c
@@ -36,6 +36,7 @@ typedef struct __attribute__((packed)) {
 #include "ios_kernel/ios_kernel.bin.h"
 #include "ios_mcp/ios_mcp.bin.h"
 #include "ios_usb/ios_usb.bin.h"
+#include "ios_fs/ios_fs.bin.h"
 
 /* ROP CHAIN STARTS HERE (0x1015BD78) */
 static const int final_chain[] = {
@@ -319,6 +320,10 @@ static void uhs_exploit_init(int dev_uhs_0_handle) {
     payloads       = (payload_info_t *) 0xF4160000;
     payloads->size = sizeof(ios_mcp);
     memcpy(payloads->data, ios_mcp, payloads->size);
+
+    payloads       = (payload_info_t *) 0xF4170000;
+    payloads->size = sizeof(ios_fs);
+    memcpy(payloads->data, ios_fs, payloads->size);
 
     pretend_root_hub[33] = 0x500000;
     pretend_root_hub[78] = 0;

--- a/source/ios_exploit.c
+++ b/source/ios_exploit.c
@@ -321,6 +321,10 @@ static void uhs_exploit_init(int dev_uhs_0_handle) {
     payloads->size = sizeof(ios_mcp);
     memcpy(payloads->data, ios_mcp, payloads->size);
 
+    if (sizeof(ios_mcp) > 0xF4170000 - 0xF4160000) {
+        OSFatal("ios_mcp is too big and overlaps with ios_fs");
+    }
+
     payloads       = (payload_info_t *) 0xF4170000;
     payloads->size = sizeof(ios_fs);
     memcpy(payloads->data, ios_fs, payloads->size);

--- a/source/ios_exploit.c
+++ b/source/ios_exploit.c
@@ -33,10 +33,10 @@ typedef struct __attribute__((packed)) {
 } payload_info_t;
 
 /* YOUR ARM CODE HERE (starts at ARM_CODE_BASE) */
+#include "ios_fs/ios_fs.bin.h"
 #include "ios_kernel/ios_kernel.bin.h"
 #include "ios_mcp/ios_mcp.bin.h"
 #include "ios_usb/ios_usb.bin.h"
-#include "ios_fs/ios_fs.bin.h"
 
 /* ROP CHAIN STARTS HERE (0x1015BD78) */
 static const int final_chain[] = {

--- a/source/ios_exploit.c
+++ b/source/ios_exploit.c
@@ -309,26 +309,26 @@ static void uhs_exploit_init(int dev_uhs_0_handle) {
     ayylmao[5] = 1;
     ayylmao[8] = 0x500000;
 
-    static_assert(sizeof(second_chain) <  0xF4130000 - 0xF4120000, "second_chain is too big");
+    static_assert(sizeof(second_chain) < 0xF4130000 - 0xF4120000, "second_chain is too big");
     memcpy((char *) (0xF4120000), second_chain, sizeof(second_chain));
-    static_assert(sizeof(final_chain) <  0xF4140000 - 0xF4130000, "second_chain is too big");
+    static_assert(sizeof(final_chain) < 0xF4140000 - 0xF4130000, "second_chain is too big");
     memcpy((char *) (0xF4130000), final_chain, sizeof(final_chain));
-    static_assert(sizeof(final_chain) <  0xF4148000 - 0xF4140000, "ios_kernel is too big");
+    static_assert(sizeof(final_chain) < 0xF4148000 - 0xF4140000, "ios_kernel is too big");
     memcpy((char *) (0xF4140000), ios_kernel, sizeof(ios_kernel));
 
-    static_assert(sizeof(ios_usb) <  0xF4160000 - 0xF4148000, "IOS_USB is too big");
+    static_assert(sizeof(ios_usb) < 0xF4160000 - 0xF4148000, "IOS_USB is too big");
     payload_info_t *payloads = (payload_info_t *) 0xF4148000;
     payloads->size           = sizeof(ios_usb);
     memcpy(payloads->data, ios_usb, payloads->size);
 
 
-    static_assert(sizeof(ios_mcp) <  0xF4170000 - 0xF4160000, "IOS_MCP is too big");
+    static_assert(sizeof(ios_mcp) < 0xF4170000 - 0xF4160000, "IOS_MCP is too big");
     payloads       = (payload_info_t *) 0xF4160000;
     payloads->size = sizeof(ios_mcp);
     memcpy(payloads->data, ios_mcp, payloads->size);
 
 
-    static_assert(sizeof(ios_mcp) <  0xF4180000 - 0xF4170000, "IOS_FS is too big");
+    static_assert(sizeof(ios_mcp) < 0xF4180000 - 0xF4170000, "IOS_FS is too big");
     payloads       = (payload_info_t *) 0xF4170000;
     payloads->size = sizeof(ios_fs);
     memcpy(payloads->data, ios_fs, payloads->size);

--- a/source/ios_exploit.c
+++ b/source/ios_exploit.c
@@ -309,22 +309,26 @@ static void uhs_exploit_init(int dev_uhs_0_handle) {
     ayylmao[5] = 1;
     ayylmao[8] = 0x500000;
 
+    static_assert(sizeof(second_chain) <  0xF4130000 - 0xF4120000, "second_chain is too big");
     memcpy((char *) (0xF4120000), second_chain, sizeof(second_chain));
+    static_assert(sizeof(final_chain) <  0xF4140000 - 0xF4130000, "second_chain is too big");
     memcpy((char *) (0xF4130000), final_chain, sizeof(final_chain));
+    static_assert(sizeof(final_chain) <  0xF4148000 - 0xF4140000, "ios_kernel is too big");
     memcpy((char *) (0xF4140000), ios_kernel, sizeof(ios_kernel));
 
+    static_assert(sizeof(ios_usb) <  0xF4160000 - 0xF4148000, "IOS_USB is too big");
     payload_info_t *payloads = (payload_info_t *) 0xF4148000;
     payloads->size           = sizeof(ios_usb);
     memcpy(payloads->data, ios_usb, payloads->size);
 
+
+    static_assert(sizeof(ios_mcp) <  0xF4170000 - 0xF4160000, "IOS_MCP is too big");
     payloads       = (payload_info_t *) 0xF4160000;
     payloads->size = sizeof(ios_mcp);
     memcpy(payloads->data, ios_mcp, payloads->size);
 
-    if (sizeof(ios_mcp) > 0xF4170000 - 0xF4160000) {
-        OSFatal("ios_mcp is too big and overlaps with ios_fs");
-    }
 
+    static_assert(sizeof(ios_mcp) <  0xF4180000 - 0xF4170000, "IOS_FS is too big");
     payloads       = (payload_info_t *) 0xF4170000;
     payloads->size = sizeof(ios_fs);
     memcpy(payloads->data, ios_fs, payloads->size);
@@ -341,7 +345,7 @@ static void uhs_exploit_init(int dev_uhs_0_handle) {
 
 static int uhs_write32(int dev_uhs_0_handle, int arm_addr, int val) {
     ayylmao[520] = arm_addr - 24;             //!  The address to be overwritten, minus 24 bytes
-    DCStoreRange(ayylmao, 521 * 4);           //!  Make CPU fetch new data (with updated adress)
+    DCStoreRange(ayylmao, 521 * 4);           //!  Make CPU fetch new data (with updated address)
     OSSleepTicks(0x200000);                   //!  Improves stability
     int request_buffer[] = {-(0xBEA2C), val}; //! -(0xBEA2C) gets IOS_USB to read from the middle of MEM1
     int output_buffer[32];

--- a/source/ios_fs/.gitignore
+++ b/source/ios_fs/.gitignore
@@ -1,0 +1,4 @@
+build/
+*.bin
+*.bin.h
+*.elf

--- a/source/ios_fs/Makefile
+++ b/source/ios_fs/Makefile
@@ -40,12 +40,14 @@ INCLUDES	:= source
 #---------------------------------------------------------------------------------
 # options for code generation
 #---------------------------------------------------------------------------------
-CFLAGS	:= -Wall -std=gnu11 -Os $(MACHDEP) $(INCLUDE) -Wno-array-bounds -fno-builtin
+LTOFLAGS    := -flto=auto -fno-fat-lto-objects -fuse-linker-plugin -Os
+
+CFLAGS	:= -Wall -std=gnu11 $(MACHDEP) $(INCLUDE) -Wno-array-bounds -fno-builtin $(LTOFLAGS)
 
 ASFLAGS	:= $(MACHDEP)
 
 LDFLAGS := -nostartfiles -nodefaultlibs -mbig-endian \
-	-Wl,-L $(TOPDIR) -Wl,-Map,$(notdir $*.map),-T $(TOPDIR)/link.ld -flto
+	-Wl,-L $(TOPDIR) -Wl,-Map,$(notdir $*.map),-T $(TOPDIR)/link.ld $(LTOFLAGS)
 
 LIBS	:= -lgcc
 

--- a/source/ios_fs/Makefile
+++ b/source/ios_fs/Makefile
@@ -45,7 +45,7 @@ CFLAGS	:= -Wall -std=gnu11 -Os $(MACHDEP) $(INCLUDE) -Wno-array-bounds -fno-buil
 ASFLAGS	:= $(MACHDEP)
 
 LDFLAGS := -nostartfiles -nodefaultlibs -mbig-endian \
-	-Wl,-L $(TOPDIR) -Wl,-Map,$(notdir $*.map),-T $(TOPDIR)/link.ld
+	-Wl,-L $(TOPDIR) -Wl,-Map,$(notdir $*.map),-T $(TOPDIR)/link.ld -flto
 
 LIBS	:= -lgcc
 

--- a/source/ios_fs/Makefile
+++ b/source/ios_fs/Makefile
@@ -1,0 +1,147 @@
+#-------------------------------------------------------------------------------
+.SUFFIXES:
+#-------------------------------------------------------------------------------
+
+ifeq ($(strip $(DEVKITPRO)),)
+$(error "Please set DEVKITPRO in your environment. export DEVKITPRO=<path to>/devkitpro")
+endif
+
+TOPDIR ?= $(CURDIR)
+
+#---------------------------------------------------------------------------------
+# iosu_rules
+#---------------------------------------------------------------------------------
+ifeq ($(strip $(DEVKITARM)),)
+$(error "Please set DEVKITARM in your environment. export DEVKITARM=<path to>/devkitARM")
+endif
+
+include $(DEVKITARM)/base_rules
+export OBJDUMP := $(PREFIX)objdump
+
+MACHDEP = -DSTARBUCK -mbig-endian -mcpu=arm926ej-s -msoft-float -mfloat-abi=soft
+
+%.elf:
+	@echo linking ... $(notdir $@)
+	$(SILENTCMD)$(LD) $(LDFLAGS) $(OFILES) $(LIBPATHS) $(LIBS) -o $@
+#---------------------------------------------------------------------------------
+
+#---------------------------------------------------------------------------------
+# TARGET is the name of the output
+# SOURCES is a list of directories containing source code
+# DATA is a list of directories containing data files
+# INCLUDES is a list of directories containing header files
+#---------------------------------------------------------------------------------
+TARGET		:= $(notdir $(CURDIR))
+BUILD		:= build
+SOURCES		:= source
+DATA		:= data
+INCLUDES	:= source
+
+#---------------------------------------------------------------------------------
+# options for code generation
+#---------------------------------------------------------------------------------
+CFLAGS	:= -Wall -std=gnu11 -Os $(MACHDEP) $(INCLUDE) -Wno-array-bounds -fno-builtin
+
+ASFLAGS	:= $(MACHDEP)
+
+LDFLAGS := -nostartfiles -nodefaultlibs -mbig-endian \
+	-Wl,-L $(TOPDIR) -Wl,-Map,$(notdir $*.map),-T $(TOPDIR)/link.ld
+
+LIBS	:= -lgcc
+
+#-------------------------------------------------------------------------------
+# list of directories containing libraries, this must be the top level
+# containing include and lib
+#-------------------------------------------------------------------------------
+LIBDIRS	:= 
+
+#---------------------------------------------------------------------------------
+# no real need to edit anything past this point unless you need to add additional
+# rules for different file extensions
+#---------------------------------------------------------------------------------
+ifneq ($(BUILD),$(notdir $(CURDIR)))
+#---------------------------------------------------------------------------------
+
+export TARGETNAME := $(TARGET)
+
+export OUTPUT	:= $(CURDIR)/$(TARGET)
+export TOPDIR	:= $(CURDIR)
+
+export VPATH	:= $(foreach dir,$(SOURCES),$(CURDIR)/$(dir)) \
+	$(foreach dir,$(DATA),$(CURDIR)/$(dir))
+
+export DEPSDIR	:= $(CURDIR)/$(BUILD)
+
+CFILES	:= $(foreach dir,$(SOURCES),$(notdir $(wildcard $(dir)/*.c)))
+SFILES	:= $(foreach dir,$(SOURCES),$(notdir $(wildcard $(dir)/*.s)))
+BINFILES	:= $(foreach dir,$(DATA),$(notdir $(wildcard $(dir)/*.*)))
+
+export LD	:= $(CC)
+
+export OFILES_BIN	:= $(addsuffix .o,$(BINFILES))
+export OFILES_SRC	:= $(SFILES:.s=.o) $(CFILES:.c=.o)
+export OFILES	:= $(OFILES_BIN) $(OFILES_SRC)
+export HFILES_BIN	:= $(addsuffix .h,$(subst .,_,$(BINFILES)))
+
+export INCLUDE	:= $(foreach dir,$(INCLUDES),-I$(CURDIR)/$(dir)) \
+	$(foreach dir,$(LIBDIRS),-I$(dir)/include) \
+	-I$(CURDIR)/$(BUILD)
+
+export LIBPATHS	:= $(foreach dir,$(LIBDIRS),-L$(dir)/lib)
+
+.PHONY: $(BUILD) clean all
+#---------------------------------------------------------------------------------
+all: $(BUILD)
+
+$(BUILD):
+	@[ -d $@ ] || mkdir -p $@
+	@$(MAKE) --no-print-directory -C $(BUILD) -f $(CURDIR)/Makefile
+
+#---------------------------------------------------------------------------------
+clean:
+	@echo clean ...
+	@rm -fr $(BUILD) $(TARGET).elf $(TARGET).bin $(TARGET).bin.h $(TARGET)_syms.h
+
+#---------------------------------------------------------------------------------
+else
+
+DEPENDS := $(OFILES:.o=.d)
+
+#---------------------------------------------------------------------------------
+# main targets
+#---------------------------------------------------------------------------------
+all	:	$(OUTPUT).bin.h $(OUTPUT)_syms.h
+
+$(OUTPUT).elf	:	$(OFILES)
+
+$(OUTPUT).bin: $(OUTPUT).elf
+	@echo "built ... $(notdir $@)"
+	@$(OBJCOPY) -j .text -j .rodata -j .data -O binary $(OUTPUT).elf $@
+	
+$(OUTPUT).bin.h: $(OUTPUT).bin
+	@raw2c $<
+	@cp $(TARGETNAME).c $@
+	
+$(OUTPUT)_syms.h:
+	@echo "#ifndef $(TARGETNAME)_SYMS_H" > $@
+	@echo "#define $(TARGETNAME)_SYMS_H" >> $@
+	@$(OBJDUMP) -EB -t -marm $(OUTPUT).elf | grep 'g     F .text' | grep -v '.hidden' | awk '{print "#define " $$6 " 0x" $$1}' >> $@
+	@$(OBJDUMP) -EB -t -marm $(OUTPUT).elf | grep -e 'g       .text' -e '_bss_' | awk '{print "#define " $$5 " 0x" $$1}' >> $@
+	@$(OBJDUMP) -EB -t -marm $(OUTPUT).elf | grep 'g     O .fn_hook_bufs' | awk '{print "#define " $$6 " 0x" $$1}' >> $@
+	@echo "#endif" >> $@
+
+$(OFILES_SRC) : $(HFILES_BIN)
+
+#-------------------------------------------------------------------------------
+# you need a rule like this for each extension you use as binary data
+#-------------------------------------------------------------------------------
+%.bin.o	%_bin.h :	%.bin
+#-------------------------------------------------------------------------------
+	@echo $(notdir $<)
+	@$(bin2o)
+
+-include $(DEPENDS)
+
+#---------------------------------------------------------------------------------------
+endif
+#---------------------------------------------------------------------------------------

--- a/source/ios_fs/link.ld
+++ b/source/ios_fs/link.ld
@@ -1,0 +1,27 @@
+OUTPUT_ARCH(arm)
+
+PROVIDE(printf = 0x107f0c84);
+
+SECTIONS
+{
+	.text (0x10700000 + 0x000F8200) : {
+	    _text_start = .;
+		*(.text*);
+		*(.rodata*);
+	}
+	_text_end = .;
+
+	.bss (0x10835000 + 0x1406554) : {
+		_bss_start = .;
+		*(.bss*);
+		*(COMMON);
+	}
+	.io_buffer : ALIGN(0x40) {
+		*(.io_buffer*);
+	}
+	_bss_end = .;
+
+	/DISCARD/ : {
+		*(*);
+	}
+}

--- a/source/ios_fs/link.ld
+++ b/source/ios_fs/link.ld
@@ -25,3 +25,6 @@ SECTIONS
 		*(*);
 	}
 }
+
+ASSERT((SIZEOF(.text)) < 0x7E00, "FS text section is too big");
+ASSERT((SIZEOF(.bss)) < 0x2C4AAC, "FS bss section is too big");

--- a/source/ios_fs/source/hook.s
+++ b/source/ios_fs/source/hook.s
@@ -1,0 +1,10 @@
+.arm
+
+.extern FSA_ioctl0x28_hook
+
+.global _FSA_ioctl0x28_hook
+_FSA_ioctl0x28_hook:
+    mov r0, r10
+    bl FSA_ioctl0x28_hook
+    mov r5, r0
+    ldr pc, =0x10701128

--- a/source/ios_fs/source/ipc_types.h
+++ b/source/ios_fs/source/ipc_types.h
@@ -1,0 +1,76 @@
+#ifndef _IPC_TYPES_H_
+#define _IPC_TYPES_H_
+
+#include "types.h"
+
+#define IOS_COMMAND_INVALID 0x00
+#define IOS_OPEN            0x01
+#define IOS_CLOSE           0x02
+#define IOS_READ            0x03
+#define IOS_WRITE           0x04
+#define IOS_SEEK            0x05
+#define IOS_IOCTL           0x06
+#define IOS_IOCTLV          0x07
+#define IOS_REPLY           0x08
+#define IOS_IPC_MSG0        0x09
+#define IOS_IPC_MSG1        0x0A
+#define IOS_IPC_MSG2        0x0B
+#define IOS_SUSPEND         0x0C
+#define IOS_RESUME          0x0D
+#define IOS_SVCMSG          0x0E
+
+
+/* IPC message */
+typedef struct ipcmessage {
+    u32 command;
+    u32 result;
+    u32 fd;
+    u32 flags;
+    u32 client_cpu;
+    u32 client_pid;
+    u64 client_gid;
+    u32 server_handle;
+
+    union {
+        u32 args[5];
+
+        struct {
+            char *device;
+            u32 mode;
+            u32 resultfd;
+        } open;
+
+        struct {
+            void *data;
+            u32 length;
+        } read, write;
+
+        struct {
+            s32 offset;
+            s32 origin;
+        } seek;
+
+        struct {
+            u32 command;
+
+            u32 *buffer_in;
+            u32 length_in;
+            u32 *buffer_io;
+            u32 length_io;
+        } ioctl;
+        struct _ioctlv {
+            u32 command;
+
+            u32 num_in;
+            u32 num_io;
+            struct _ioctlv *vector;
+        } ioctlv;
+    };
+
+    u32 prev_command;
+    u32 prev_fd;
+    u32 virt0;
+    u32 virt1;
+} __attribute__((packed)) ipcmessage;
+
+#endif

--- a/source/ios_fs/source/main.c
+++ b/source/ios_fs/source/main.c
@@ -1,3 +1,4 @@
+#include "ipc_types.h"
 #include <stdint.h>
 #include <stdio.h>
 
@@ -21,8 +22,90 @@ typedef struct __attribute__((packed)) {
     uint32_t unk3;
 } FSAClientHandle;
 
+FSAClientHandle *patchedClientHandles[0x64];
+
 int FSA_ioctl0x28_hook(FSAClientHandle *handle) {
-    printf("Updating client capabilities for handle %p\n", handle);
-    handle->caps->capabilityMask = 0xffffffffffffffff;
+    int found = 0;
+    for (int i = 0; i < 0x64; i++) {
+        if (patchedClientHandles[i] == handle) {
+            return 0;
+        }
+        if (patchedClientHandles[i] == 0) {
+            patchedClientHandles[i] = handle;
+            printf("Will patch %p in the future. Slot %d\n", handle, i);
+            found = 1;
+            break;
+        }
+    }
+    if (!found) {
+        printf("Failed to find free slot for %p\n", handle);
+    }
     return 0;
+}
+
+
+typedef struct __attribute__((packed)) {
+    ipcmessage ipcmessage;
+} ResourceRequest;
+
+int (*const real_FSA_IOCTLV)(ResourceRequest *, uint32_t, uint32_t) = (void *) 0x10703164;
+int (*const get_handle_from_val)(uint32_t)                          = (void *) 0x107046d4;
+int FSA_IOCTLV_HOOK(ResourceRequest *param_1, uint32_t u2, uint32_t u3) {
+    FSAClientHandle *clientHandle = (FSAClientHandle *) get_handle_from_val(param_1->ipcmessage.fd);
+    uint64_t oldValue             = clientHandle->caps->capabilityMask;
+    int toBeRestored              = 0;
+    for (int i = 0; i < 64; i++) {
+        if (patchedClientHandles[i] == clientHandle) {
+            clientHandle->caps->capabilityMask = 0xffffffffffffffffL;
+            printf("IOCTL: Force mask to 0xFFFFFFFFFFFFFFFF for client %08X\n", (uint32_t) clientHandle);
+            toBeRestored = 1;
+            break;
+        }
+    }
+    int res = real_FSA_IOCTLV(param_1, u2, u3);
+
+    if (toBeRestored) {
+        printf("IOCTL: Restore mask for client %08X\n", (uint32_t) clientHandle);
+        clientHandle->caps->capabilityMask = oldValue;
+    }
+
+    return res;
+}
+
+int (*const real_FSA_IOCTL)(ResourceRequest *, uint32_t, uint32_t, uint32_t) = (void *) 0x107010a8;
+
+
+int FSA_IOCTL_HOOK(ResourceRequest *param_1, uint32_t u2, uint32_t u3, uint32_t u4) {
+    FSAClientHandle *clientHandle = (FSAClientHandle *) get_handle_from_val(param_1->ipcmessage.fd);
+    uint64_t oldValue             = clientHandle->caps->capabilityMask;
+    int toBeRestored              = 0;
+    for (int i = 0; i < 64; i++) {
+        if (patchedClientHandles[i] == clientHandle) {
+            printf("IOCTL: Force mask to 0xFFFFFFFFFFFFFFFF for client %08X\n", (uint32_t) clientHandle);
+            clientHandle->caps->capabilityMask = 0xffffffffffffffffL;
+            toBeRestored                       = 1;
+            break;
+        }
+    }
+    int res = real_FSA_IOCTL(param_1, u2, u3, u4);
+
+    if (toBeRestored) {
+        printf("IOCTL: Restore mask for client %08X\n", (uint32_t) clientHandle);
+        clientHandle->caps->capabilityMask = oldValue;
+    }
+
+    return res;
+}
+
+int (*const real_FSA_IOS_Close)(FSAClientHandle *, ResourceRequest *) = (void *) 0x10704864;
+int FSA_IOS_Close_Hook(uint32_t fd, ResourceRequest *u1) {
+    FSAClientHandle *clientHandle = (FSAClientHandle *) get_handle_from_val(fd);
+    for (int i = 0; i < 64; i++) {
+        if (patchedClientHandles[i] == clientHandle) {
+            printf("Close: %p will be closed, reset slot %d\n", clientHandle, i);
+            patchedClientHandles[i] = 0;
+            break;
+        }
+    }
+    return real_FSA_IOS_Close(fd, u1);
 }

--- a/source/ios_fs/source/main.c
+++ b/source/ios_fs/source/main.c
@@ -1,6 +1,6 @@
 #include "ipc_types.h"
-#include <stdint.h>
 #include <assert.h>
+#include <stdint.h>
 
 typedef struct __attribute__((packed)) {
     uint32_t initialized;
@@ -12,13 +12,13 @@ typedef struct __attribute__((packed)) {
     uint8_t unk1[0x4518];
     char unk2[0x280];
     char unk3[0x280];
-    void* mutex;
+    void *mutex;
 } FSAProcessData;
 static_assert(sizeof(FSAProcessData) == 0x4A3C, "FSAProcessData: wrong size");
 
 typedef struct __attribute__((packed)) {
     uint32_t opened;
-    FSAProcessData* processData;
+    FSAProcessData *processData;
     char unk0[0x10];
     char unk1[0x90];
     uint32_t unk2;
@@ -86,7 +86,7 @@ int FSA_IOCTL_HOOK(ResourceRequest *request, uint32_t u2, uint32_t u3, uint32_t 
         if (patchedClientHandles[i] == clientHandle) {
             // printf("IOCTL: Force mask to 0xFFFFFFFFFFFFFFFF for client %08X\n", (uint32_t) clientHandle);
             clientHandle->processData->capabilityMask = 0xffffffffffffffffL;
-            toBeRestored                       = 1;
+            toBeRestored                              = 1;
             break;
         }
     }

--- a/source/ios_fs/source/main.c
+++ b/source/ios_fs/source/main.c
@@ -13,7 +13,7 @@ typedef struct __attribute__((packed)) {
 
 typedef struct __attribute__((packed)) {
     uint32_t opened;
-    FSAClientCapabilites* caps;
+    FSAClientCapabilites *caps;
     char unk0[0x10];
     char unk1[0x90];
     uint32_t unk2;
@@ -21,8 +21,7 @@ typedef struct __attribute__((packed)) {
     uint32_t unk3;
 } FSAClientHandle;
 
-int FSA_ioctl0x28_hook(FSAClientHandle* handle)
-{
+int FSA_ioctl0x28_hook(FSAClientHandle *handle) {
     printf("Updating client capabilities for handle %p\n", handle);
     handle->caps->capabilityMask = 0xffffffffffffffff;
     return 0;

--- a/source/ios_fs/source/main.c
+++ b/source/ios_fs/source/main.c
@@ -1,0 +1,29 @@
+#include <stdint.h>
+#include <stdio.h>
+
+typedef struct __attribute__((packed)) {
+    uint64_t titleId;
+    uint32_t processId;
+    uint32_t groupId;
+    uint32_t unk0;
+    uint32_t unk1;
+    uint64_t capabilityMask;
+    uint32_t unk2;
+} FSAClientCapabilites;
+
+typedef struct __attribute__((packed)) {
+    uint32_t opened;
+    FSAClientCapabilites* caps;
+    char unk0[0x10];
+    char unk1[0x90];
+    uint32_t unk2;
+    char work_dir[0x280];
+    uint32_t unk3;
+} FSAClientHandle;
+
+int FSA_ioctl0x28_hook(FSAClientHandle* handle)
+{
+    printf("Updating client capabilities for handle %p\n", handle);
+    handle->caps->capabilityMask = 0xffffffffffffffff;
+    return 0;
+}

--- a/source/ios_fs/source/types.h
+++ b/source/ios_fs/source/types.h
@@ -1,0 +1,16 @@
+#ifndef _TYPES_H
+#define _TYPES_H
+
+#include <stdint.h>
+
+typedef uint8_t u8;
+typedef uint16_t u16;
+typedef uint32_t u32;
+typedef uint64_t u64;
+
+typedef int8_t s8;
+typedef int16_t s16;
+typedef int32_t s32;
+typedef int64_t s64;
+
+#endif

--- a/source/ios_kernel/Makefile
+++ b/source/ios_kernel/Makefile
@@ -40,12 +40,14 @@ INCLUDES	:= source
 #---------------------------------------------------------------------------------
 # options for code generation
 #---------------------------------------------------------------------------------
-CFLAGS	:= -Wall -Wextra -std=gnu11 -Os $(MACHDEP) $(INCLUDE) -fno-builtin
+LTOFLAGS    := -flto=auto -fno-fat-lto-objects -fuse-linker-plugin -Os
+
+CFLAGS	:= -Wall -Wextra -std=gnu11 $(MACHDEP) $(INCLUDE) -fno-builtin $(LTOFLAGS)
 
 ASFLAGS	:= $(MACHDEP)
 
 LDFLAGS := -nostartfiles -nodefaultlibs -mbig-endian \
-	-Wl,-L $(TOPDIR) -Wl,-Map,$(notdir $*.map),-T $(TOPDIR)/link.ld -flto
+	-Wl,-L $(TOPDIR) -Wl,-Map,$(notdir $*.map),-T $(TOPDIR)/link.ld $(LTOFLAGS)
 
 LIBS	:= -lgcc
 

--- a/source/ios_kernel/source/instant_patches.c
+++ b/source/ios_kernel/source/instant_patches.c
@@ -21,8 +21,8 @@
  * 3. This notice may not be removed or altered from any source
  * distribution.
  ***************************************************************************/
-#include "../../ios_mcp/ios_mcp_syms.h"
 #include "../../ios_fs/ios_fs_syms.h"
+#include "../../ios_mcp/ios_mcp_syms.h"
 #include "elf_patcher.h"
 #include "ios_mcp_patches.h"
 #include "kernel_patches.h"

--- a/source/ios_kernel/source/instant_patches.c
+++ b/source/ios_kernel/source/instant_patches.c
@@ -22,6 +22,7 @@
  * distribution.
  ***************************************************************************/
 #include "../../ios_mcp/ios_mcp_syms.h"
+#include "../../ios_fs/ios_fs_syms.h"
 #include "elf_patcher.h"
 #include "ios_mcp_patches.h"
 #include "kernel_patches.h"
@@ -131,4 +132,6 @@ void instant_patches_setup(void) {
     map_info.type   = 3; // 0 = undefined, 1 = kernel only, 2 = read only, 3 = read write
     map_info.cached = 0xFFFFFFFF;
     _iosMapSharedUserExecution(&map_info);
+
+    *(volatile u32 *) 0x10701248 = _FSA_ioctl0x28_hook;
 }

--- a/source/ios_kernel/source/instant_patches.c
+++ b/source/ios_kernel/source/instant_patches.c
@@ -52,10 +52,6 @@ void instant_patches_setup(void) {
     // Add IOCTL 0x28 to indicate the calling client should have full fs permissions
     *(volatile u32 *) 0x10701248 = _FSA_ioctl0x28_hook;
 
-    // patch FSA raw access
-    *(volatile u32 *) 0x1070FAE8 = 0x05812070;
-    *(volatile u32 *) 0x1070FAEC = 0xEAFFFFF9;
-
     // Give clients that called IOCTL 0x28 full permissions
     *(volatile u32 *) 0x10704540 = ARM_BL(0x10704540, FSA_IOCTLV_HOOK);
     *(volatile u32 *) 0x107044f0 = ARM_BL(0x107044f0, FSA_IOCTL_HOOK);

--- a/source/ios_kernel/source/instant_patches.c
+++ b/source/ios_kernel/source/instant_patches.c
@@ -48,6 +48,9 @@ void instant_patches_setup(void) {
 
     *(volatile u32 *) 0x0812CD2C = ARM_B(0x0812CD2C, kernel_syscall_0x81);
 
+    // Patch IOCTL 0x28 to give the calling client full fs permission
+    *(volatile u32 *) 0x10701248 = _FSA_ioctl0x28_hook;
+
     // patch FSA raw access
     *(volatile u32 *) 0x1070FAE8 = 0x05812070;
     *(volatile u32 *) 0x1070FAEC = 0xEAFFFFF9;
@@ -132,6 +135,4 @@ void instant_patches_setup(void) {
     map_info.type   = 3; // 0 = undefined, 1 = kernel only, 2 = read only, 3 = read write
     map_info.cached = 0xFFFFFFFF;
     _iosMapSharedUserExecution(&map_info);
-
-    *(volatile u32 *) 0x10701248 = _FSA_ioctl0x28_hook;
 }

--- a/source/ios_kernel/source/instant_patches.c
+++ b/source/ios_kernel/source/instant_patches.c
@@ -24,6 +24,7 @@
 #include "../../ios_fs/ios_fs_syms.h"
 #include "../../ios_mcp/ios_mcp_syms.h"
 #include "elf_patcher.h"
+#include "ios_fs_patches.h"
 #include "ios_mcp_patches.h"
 #include "kernel_patches.h"
 #include "types.h"
@@ -48,12 +49,19 @@ void instant_patches_setup(void) {
 
     *(volatile u32 *) 0x0812CD2C = ARM_B(0x0812CD2C, kernel_syscall_0x81);
 
-    // Patch IOCTL 0x28 to give the calling client full fs permission
+    // Add IOCTL 0x28 to indicate the calling client should have full fs permissions
     *(volatile u32 *) 0x10701248 = _FSA_ioctl0x28_hook;
 
     // patch FSA raw access
     *(volatile u32 *) 0x1070FAE8 = 0x05812070;
     *(volatile u32 *) 0x1070FAEC = 0xEAFFFFF9;
+
+    // Give clients that called IOCTL 0x28 full permissions
+    *(volatile u32 *) 0x10704540 = ARM_BL(0x10704540, FSA_IOCTLV_HOOK);
+    *(volatile u32 *) 0x107044f0 = ARM_BL(0x107044f0, FSA_IOCTL_HOOK);
+    *(volatile u32 *) 0x10704458 = ARM_BL(0x10704458, FSA_IOS_Close_Hook);
+
+    reset_fs_bss();
 
     // patch /dev/odm IOCTL 0x06 to return the disc key if in_buf[0] > 2.
     *(volatile u32 *) 0x10739948 = 0xe3a0b001; // mov r11, 0x01

--- a/source/ios_kernel/source/instant_patches.c
+++ b/source/ios_kernel/source/instant_patches.c
@@ -52,6 +52,10 @@ void instant_patches_setup(void) {
     // Add IOCTL 0x28 to indicate the calling client should have full fs permissions
     *(volatile u32 *) 0x10701248 = _FSA_ioctl0x28_hook;
 
+    // patch FSA raw access
+    *(volatile u32 *) 0x1070FAE8 = 0x05812070;
+    *(volatile u32 *) 0x1070FAEC = 0xEAFFFFF9;
+
     // Give clients that called IOCTL 0x28 full permissions
     *(volatile u32 *) 0x10704540 = ARM_BL(0x10704540, FSA_IOCTLV_HOOK);
     *(volatile u32 *) 0x107044f0 = ARM_BL(0x107044f0, FSA_IOCTL_HOOK);

--- a/source/ios_kernel/source/ios_fs_patches.c
+++ b/source/ios_kernel/source/ios_fs_patches.c
@@ -1,0 +1,45 @@
+/***************************************************************************
+* Copyright (C) 2016
+* by Dimok
+*
+* This software is provided 'as-is', without any express or implied
+* warranty. In no event will the authors be held liable for any
+* damages arising from the use of this software.
+*
+* Permission is granted to anyone to use this software for any
+* purpose, including commercial applications, and to alter it and
+* redistribute it freely, subject to the following restrictions:
+*
+* 1. The origin of this software must not be misrepresented; you
+* must not claim that you wrote the original software. If you use
+* this software in a product, an acknowledgment in the product
+* documentation would be appreciated but is not required.
+*
+* 2. Altered source versions must be plainly marked as such, and
+* must not be misrepresented as being the original software.
+*
+* 3. This notice may not be removed or altered from any source
+* distribution.
+***************************************************************************/
+#include "ios_fs_patches.h"
+#include "../../ios_fs/ios_fs_syms.h"
+#include "elf_patcher.h"
+#include "types.h"
+
+#define FS_PHYS_DIFF 0
+
+u32 fs_get_phys_code_base(void) {
+    return _text_start + FS_PHYS_DIFF;
+}
+
+void fs_run_patches(u32 ios_elf_start) {
+    section_write(ios_elf_start, _text_start, (void *) fs_get_phys_code_base(), _text_end - _text_start);
+    section_write_bss(ios_elf_start, _bss_start, _bss_end - _bss_start);
+
+    // Patch IOCTL 0x28 to give the calling client full fs permission
+    section_write_word(ios_elf_start, 0x10701248, _FSA_ioctl0x28_hook);
+
+    // patch FSA raw access
+    section_write_word(ios_elf_start, 0x1070FAE8, 0x05812070);
+    section_write_word(ios_elf_start, 0x1070FAEC, 0xEAFFFFF9);
+}

--- a/source/ios_kernel/source/ios_fs_patches.c
+++ b/source/ios_kernel/source/ios_fs_patches.c
@@ -25,6 +25,7 @@
 #include "../../ios_fs/ios_fs_syms.h"
 #include "elf_patcher.h"
 #include "types.h"
+#include <string.h>
 
 #define FS_PHYS_DIFF 0
 
@@ -33,7 +34,7 @@ u32 fs_get_phys_code_base(void) {
 }
 
 void reset_fs_bss() {
-    memset(_bss_start, 0, _bss_end - _bss_start);
+    memset((void*) _bss_start, 0, _bss_end - _bss_start);
 }
 
 void fs_run_patches(uint32_t ios_elf_start) {

--- a/source/ios_kernel/source/ios_fs_patches.c
+++ b/source/ios_kernel/source/ios_fs_patches.c
@@ -47,8 +47,4 @@ void fs_run_patches(uint32_t ios_elf_start) {
     section_write_word(ios_elf_start, 0x10704540, ARM_BL(0x10704540, FSA_IOCTLV_HOOK));
     section_write_word(ios_elf_start, 0x107044f0, ARM_BL(0x107044f0, FSA_IOCTL_HOOK));
     section_write_word(ios_elf_start, 0x10704458, ARM_BL(0x10704458, FSA_IOS_Close_Hook));
-
-    // patch FSA raw access
-    section_write_word(ios_elf_start, 0x1070FAE8, 0x05812070);
-    section_write_word(ios_elf_start, 0x1070FAEC, 0xEAFFFFF9);
 }

--- a/source/ios_kernel/source/ios_fs_patches.c
+++ b/source/ios_kernel/source/ios_fs_patches.c
@@ -34,7 +34,7 @@ u32 fs_get_phys_code_base(void) {
 }
 
 void reset_fs_bss() {
-    memset((void*) _bss_start, 0, _bss_end - _bss_start);
+    memset((void *) _bss_start, 0, _bss_end - _bss_start);
 }
 
 void fs_run_patches(uint32_t ios_elf_start) {

--- a/source/ios_kernel/source/ios_fs_patches.c
+++ b/source/ios_kernel/source/ios_fs_patches.c
@@ -48,4 +48,8 @@ void fs_run_patches(uint32_t ios_elf_start) {
     section_write_word(ios_elf_start, 0x10704540, ARM_BL(0x10704540, FSA_IOCTLV_HOOK));
     section_write_word(ios_elf_start, 0x107044f0, ARM_BL(0x107044f0, FSA_IOCTL_HOOK));
     section_write_word(ios_elf_start, 0x10704458, ARM_BL(0x10704458, FSA_IOS_Close_Hook));
+
+    // patch FSA raw access
+    section_write_word(ios_elf_start, 0x1070FAE8, 0x05812070);
+    section_write_word(ios_elf_start, 0x1070FAEC, 0xEAFFFFF9);
 }

--- a/source/ios_kernel/source/ios_fs_patches.h
+++ b/source/ios_kernel/source/ios_fs_patches.h
@@ -1,0 +1,30 @@
+/***************************************************************************
+* Copyright (C) 2016
+* by Dimok
+*
+* This software is provided 'as-is', without any express or implied
+* warranty. In no event will the authors be held liable for any
+* damages arising from the use of this software.
+*
+* Permission is granted to anyone to use this software for any
+* purpose, including commercial applications, and to alter it and
+* redistribute it freely, subject to the following restrictions:
+*
+* 1. The origin of this software must not be misrepresented; you
+* must not claim that you wrote the original software. If you use
+* this software in a product, an acknowledgment in the product
+* documentation would be appreciated but is not required.
+*
+* 2. Altered source versions must be plainly marked as such, and
+* must not be misrepresented as being the original software.
+*
+* 3. This notice may not be removed or altered from any source
+* distribution.
+***************************************************************************/
+#ifndef _FS_PATCHES_H_
+#define _FS_PATCHES_H_
+
+u32 fs_get_phys_code_base(void);
+void fs_run_patches(u32 ios_elf_start);
+
+#endif

--- a/source/ios_kernel/source/ios_fs_patches.h
+++ b/source/ios_kernel/source/ios_fs_patches.h
@@ -24,7 +24,11 @@
 #ifndef _FS_PATCHES_H_
 #define _FS_PATCHES_H_
 
-u32 fs_get_phys_code_base(void);
-void fs_run_patches(u32 ios_elf_start);
+#include <stdint.h>
+
+uint32_t fs_get_phys_code_base(void);
+void fs_run_patches(uint32_t ios_elf_start);
+
+void reset_fs_bss();
 
 #endif

--- a/source/ios_kernel/source/kernel_patches.c
+++ b/source/ios_kernel/source/kernel_patches.c
@@ -24,6 +24,7 @@
 #include "kernel_patches.h"
 #include "../../common/kernel_commands.h"
 #include "elf_patcher.h"
+#include "ios_fs_patches.h"
 #include "ios_mcp_patches.h"
 #include "thread.h"
 #include "types.h"
@@ -105,6 +106,7 @@ void kernel_launch_ios(u32 launch_address, u32 L, u32 C, u32 H) {
         //! try to keep the order of virt. addresses to reduce the memmove amount
         mcp_run_patches(ios_elf_start);
         kernel_run_patches(ios_elf_start);
+        fs_run_patches(ios_elf_start);
 
         restore_mmu(control_register);
         enable_interrupts(level);

--- a/source/ios_kernel/source/main.c
+++ b/source/ios_kernel/source/main.c
@@ -27,6 +27,7 @@
 #include "utils.h"
 
 #define USB_PHYS_CODE_BASE 0x101312D0
+#define FS_PHYS_CODE_BASE 0x107F8200
 
 typedef struct {
     u32 size;
@@ -90,6 +91,9 @@ int _main() {
 
     payloads = (payload_info_t *) 0x00160000;
     kernel_memcpy((void *) mcp_get_phys_code_base(), payloads->data, payloads->size);
+
+    payloads = (payload_info_t *) 0x00170000;
+    kernel_memcpy((void *) FS_PHYS_CODE_BASE, payloads->data, payloads->size);
 
     // run all instant patches as necessary
     instant_patches_setup();

--- a/source/ios_kernel/source/main.c
+++ b/source/ios_kernel/source/main.c
@@ -27,7 +27,7 @@
 #include "utils.h"
 
 #define USB_PHYS_CODE_BASE 0x101312D0
-#define FS_PHYS_CODE_BASE 0x107F8200
+#define FS_PHYS_CODE_BASE  0x107F8200
 
 typedef struct {
     u32 size;

--- a/source/ios_kernel/source/utils.c
+++ b/source/ios_kernel/source/utils.c
@@ -22,6 +22,8 @@
  * distribution.
  ***************************************************************************/
 
+#include <stddef.h>
+
 // this memcpy is optimized for speed and to work with MEM1 32 bit access alignment requirement
 void reverse_memcpy(void *dst, const void *src, unsigned int size) {
     const unsigned char *src_p;
@@ -81,4 +83,14 @@ void reverse_memcpy(void *dst, const void *src, unsigned int size) {
 
     while (size--)
         *dst_p-- = *src_p--;
+}
+
+void *memset(void *dst, int val, size_t size) {
+    char *_dst = dst;
+
+    int i;
+    for (i = 0; i < size; i++)
+        _dst[i] = val;
+
+    return dst;
 }

--- a/source/ios_mcp/Makefile
+++ b/source/ios_mcp/Makefile
@@ -40,12 +40,14 @@ INCLUDES	:= source
 #---------------------------------------------------------------------------------
 # options for code generation
 #---------------------------------------------------------------------------------
-CFLAGS	:= -Wall -Wextra -std=gnu11 -Os $(MACHDEP) $(INCLUDE) -fno-builtin
+LTOFLAGS    := -flto=auto -fno-fat-lto-objects -fuse-linker-plugin -Os
+
+CFLAGS	:= -Wall -Wextra -std=gnu11 $(MACHDEP) $(INCLUDE) -fno-builtin $(LTOFLAGS)
 
 ASFLAGS	:= $(MACHDEP)
 
 LDFLAGS := -nostartfiles -nodefaultlibs -mbig-endian \
-	-Wl,-L $(TOPDIR) -Wl,-Map,$(notdir $*.map),-T $(TOPDIR)/link.ld -flto
+	-Wl,-L $(TOPDIR) -Wl,-Map,$(notdir $*.map),-T $(TOPDIR)/link.ld $(LTOFLAGS)
 
 LIBS	:= -lgcc
 

--- a/source/ios_usb/Makefile
+++ b/source/ios_usb/Makefile
@@ -40,12 +40,14 @@ INCLUDES	:= source
 #---------------------------------------------------------------------------------
 # options for code generation
 #---------------------------------------------------------------------------------
-CFLAGS	:= -Wall -Wextra -std=gnu11 -Os $(MACHDEP) $(INCLUDE) -fno-builtin
+LTOFLAGS    := -flto=auto -fno-fat-lto-objects -fuse-linker-plugin -Os
+
+CFLAGS	:= -Wall -Wextra -std=gnu11 $(MACHDEP) $(INCLUDE) -fno-builtin $(LTOFLAGS)
 
 ASFLAGS	:= $(MACHDEP)
 
 LDFLAGS := -nostartfiles -nodefaultlibs -mbig-endian \
-	-Wl,-L $(TOPDIR) -Wl,-Map,$(notdir $*.map),-T $(TOPDIR)/link.ld -flto
+	-Wl,-L $(TOPDIR) -Wl,-Map,$(notdir $*.map),-T $(TOPDIR)/link.ld $(LTOFLAGS)
 
 LIBS	:= -lgcc
 


### PR DESCRIPTION
Just adding `-flto` to LDFLAGs does nothing. You also need to tell the compiler to crate LTO compatible objects and pass the level of optimisation to the linker. See GCC docs for more information:
https://gcc.gnu.org/onlinedocs/gcc/Optimize-Options.html#index-flto
> When invoked with source code, it generates GIMPLE (one of GCC’s internal representations) and writes it to special ELF sections in the object file. When the object files are linked together, all the function bodies are read from these ELF sections and instantiated as if they had been part of the same translation unit.

> -flto and optimization options should be specified at compile time and during the final link.

https://gcc.gnu.org/onlinedocs/gcc/Optimize-Options.html#index-ffat-lto-objects
https://gcc.gnu.org/onlinedocs/gcc/Optimize-Options.html#index-fuse-linker-plugin
https://gcc.gnu.org/wiki/LinkTimeOptimization#Requirements