### PR TITLE
Make sure symbol files are updated if elf changes

### DIFF
--- a/source/ios_fs/Makefile
+++ b/source/ios_fs/Makefile
@@ -122,7 +122,7 @@ $(OUTPUT).bin.h: $(OUTPUT).bin
 	@raw2c $<
 	@cp $(TARGETNAME).c $@
 	
-$(OUTPUT)_syms.h:
+$(OUTPUT)_syms.h: $(OUTPUT).elf
 	@echo "#ifndef $(TARGETNAME)_SYMS_H" > $@
 	@echo "#define $(TARGETNAME)_SYMS_H" >> $@
 	@$(OBJDUMP) -EB -t -marm $(OUTPUT).elf | grep 'g     F .text' | grep -v '.hidden' | awk '{print "#define " $$6 " 0x" $$1}' >> $@

--- a/source/ios_kernel/Makefile
+++ b/source/ios_kernel/Makefile
@@ -110,7 +110,7 @@ DEPENDS := $(OFILES:.o=.d)
 #---------------------------------------------------------------------------------
 # main targets
 #---------------------------------------------------------------------------------
-all	:	$(OUTPUT).bin.h $(OUTPUT)_syms.h
+all	:	$(OUTPUT).bin.h
 
 $(OUTPUT).elf	:	$(OFILES)
 
@@ -121,14 +121,6 @@ $(OUTPUT).bin: $(OUTPUT).elf
 $(OUTPUT).bin.h: $(OUTPUT).bin
 	@raw2c $<
 	@cp $(TARGETNAME).c $@
-
-$(OUTPUT)_syms.h:
-	@echo "#ifndef $(TARGETNAME)_SYMS_H" > $@
-	@echo "#define $(TARGETNAME)_SYMS_H" >> $@
-	@$(OBJDUMP) -EB -t -marm $(OUTPUT).elf | grep 'g     F .text' | grep -v '.hidden' | awk '{print "#define " $$6 " 0x" $$1}' >> $@
-	@$(OBJDUMP) -EB -t -marm $(OUTPUT).elf | grep -e 'g       .text' -e '_bss_' | awk '{print "#define " $$5 " 0x" $$1}' >> $@
-	@$(OBJDUMP) -EB -t -marm $(OUTPUT).elf | grep 'g     O .fn_hook_bufs' | awk '{print "#define " $$6 " 0x" $$1}' >> $@
-	@echo "#endif" >> $@
 
 $(OFILES_SRC) : $(HFILES_BIN)
 

--- a/source/ios_mcp/Makefile
+++ b/source/ios_mcp/Makefile
@@ -122,7 +122,7 @@ $(OUTPUT).bin.h: $(OUTPUT).bin
 	@raw2c $<
 	@cp $(TARGETNAME).c $@
 	
-$(OUTPUT)_syms.h:
+$(OUTPUT)_syms.h: $(OUTPUT).elf
 	@echo "#ifndef $(TARGETNAME)_SYMS_H" > $@
 	@echo "#define $(TARGETNAME)_SYMS_H" >> $@
 	@$(OBJDUMP) -EB -t -marm $(OUTPUT).elf | grep 'g     F .text' | grep -v '.hidden' | awk '{print "#define " $$6 " 0x" $$1}' >> $@

--- a/source/ios_usb/Makefile
+++ b/source/ios_usb/Makefile
@@ -122,7 +122,7 @@ $(OUTPUT).bin.h: $(OUTPUT).bin
 	@raw2c $<
 	@cp $(TARGETNAME).c $@
 	
-$(OUTPUT)_syms.h:
+$(OUTPUT)_syms.h: $(OUTPUT).elf
 	@echo "#ifndef $(TARGETNAME)_SYMS_H" > $@
 	@echo "#define $(TARGETNAME)_SYMS_H" >> $@
 	@$(OBJDUMP) -EB -t -marm $(OUTPUT).elf | grep 'g     F .text' | grep -v '.hidden' | awk '{print "#define " $$6 " 0x" $$1}' >> $@


### PR DESCRIPTION
This makes sure the symbol files are actually updated without needing to run `make clean` before.
Looks like I missed that when writing the updated Makefiles (to be fair the original Makefiles had the same issue :p).
Also removed the symbol file creation from ios_kernel since it's unused there.