### PR TITLE
ios_kernel: Patch DLP requirement for missing archive

### DIFF
--- a/source/ios_kernel/source/instant_patches.c
+++ b/source/ios_kernel/source/instant_patches.c
@@ -49,6 +49,7 @@ typedef struct {
 #define mcp_data_phys(addr)        ((u32) (addr) -0x05074000 + 0x08234000)
 #define fsa_phys(addr)             ((u32) (addr))
 #define kernel_phys(addr)          ((u32) (addr))
+#define net_phys(addr)             ((u32) (addr))
 #define acp_text_phys(addr)        ((u32) (addr) -0xE0000000 + 0x12900000)
 #define nimboss_text_phys(addr)    ((u32) (addr) -0xe2000000 + 0x12EC0000)
 #define nimboss_rodata_phys(addr)  ((u32) (addr) -0xe2280000 + 0x13140000)
@@ -172,6 +173,11 @@ void instant_patches_setup(void) {
 
     // force check USB storage on load
     *(volatile u32 *) acp_text_phys(0xE012202C) = 0x00000001; // find USB flag
+
+    // Patch DLP to ignore error for missing title archive
+    *(volatile u32 *) net_phys(0x1239E108) = 0xEA000000; // mov r0, r0
+    *(volatile u32 *) net_phys(0x1239E10C) = 0xEA000000; // mov r0, r0
+    *(volatile u32 *) net_phys(0x1239E110) = 0xEA000000; // mov r0, r0
 
     // Patch FS to syslog everything
     *(volatile u32 *) fsa_phys(0x107F5720) = ARM_B(0x107F5720, 0x107F0C84);


### PR DESCRIPTION
On initialization, DLP tries to read from a system archive title (`0005001B1006B000`). This archive is used for updating 3DS clients which have an old system version to a newer version. More info: https://www.3dbrew.org/wiki/System_Update_CFA

However, this archive doesn't exist on the Wii U, so when the reading fails, DLP checks for the OTP security level to see if it can continue initialization anyway. This also fails, so DLP ends up returning an error. Patch the OTP security check inside DLP so that it can continue even if the system archive isn't present. The patch only affects DLP