### PR TITLE
Use Stroopwafel IPC as alternative to exploit

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,4 +2,10 @@ FROM ghcr.io/wiiu-env/devkitppc:20240505
 
 COPY --from=ghcr.io/wiiu-env/libmocha:20231127 /artifacts $DEVKITPRO
 
+RUN git clone https://github.com/jan-hofmeier/libstroopwafel && \
+    cd libstroopwafel && \
+    make install && \
+    cd .. && \
+    rm -rf libstroopwafel
+
 WORKDIR project

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM ghcr.io/wiiu-env/devkitppc:20240505
 
 COPY --from=ghcr.io/wiiu-env/libmocha:20231127 /artifacts $DEVKITPRO
 
-RUN git clone https://github.com/jan-hofmeier/libstroopwafel && \
+RUN git clone https://github.com/StroopwafelCFW/libstroopwafel.git && \
     cd libstroopwafel && \
     make install && \
     cd .. && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,6 @@
-FROM ghcr.io/wiiu-env/devkitppc:20240505
+FROM ghcr.io/wiiu-env/devkitppc:20260126
 
 COPY --from=ghcr.io/wiiu-env/libmocha:20231127 /artifacts $DEVKITPRO
-
-RUN git clone https://github.com/StroopwafelCFW/libstroopwafel.git && \
-    cd libstroopwafel && \
-    make install && \
-    cd .. && \
-    rm -rf libstroopwafel
+COPY --from=ghcr.io/stroopwafelcfw/libstroopwafel:20260131 /artifacts $DEVKITPRO
 
 WORKDIR project

--- a/Makefile
+++ b/Makefile
@@ -36,7 +36,7 @@ CXXFLAGS	:= $(CFLAGS)
 ASFLAGS	:=	-g $(ARCH)
 LDFLAGS	=	-g $(ARCH) $(RPXSPECS) --entry=_start -Wl,-Map,$(notdir $*.map)
 
-LIBS	:= -lwut -lmocha
+LIBS	:= -lwut -lmocha -lstroopwafel
 
 #-------------------------------------------------------------------------------
 # list of directories containing libraries, this must be the top level

--- a/source/crt.c
+++ b/source/crt.c
@@ -2,7 +2,7 @@ void __init_wut_malloc();
 
 void __init_wut_newlib();
 
-void __init_wut_stdcpp();
+void __init_wut_thread();
 
 void __init_wut_devoptab();
 
@@ -22,7 +22,7 @@ void __attribute__((weak))
 __init_wut_() {
     __init_wut_malloc();
     __init_wut_newlib();
-    __init_wut_stdcpp();
+    __init_wut_thread();
     __init_wut_devoptab();
     if (&__init_wut_socket) __init_wut_socket();
 }
@@ -30,7 +30,6 @@ __init_wut_() {
 void __attribute__((weak))
 __fini_wut_() {
     __fini_wut_devoptab();
-    __fini_wut_stdcpp();
     __fini_wut_newlib();
     __fini_wut_malloc();
 }

--- a/source/ios_exploit.c
+++ b/source/ios_exploit.c
@@ -4,6 +4,7 @@
 #include <coreinit/thread.h>
 #include <stdint.h>
 #include <string.h>
+#include <stroopwafel/stroopwafel.h>
 
 #define ALIGN4(x)        (((x) + 3) & ~3)
 
@@ -306,17 +307,7 @@ static const int second_chain[] = {
         0x1012EA68, // 0xAC         stack pivot
 };
 
-static void uhs_exploit_init(int dev_uhs_0_handle) {
-    ayylmao[5] = 1;
-    ayylmao[8] = 0x500000;
-
-    static_assert(sizeof(second_chain) < 0xF4130000 - 0xF4120000, "second_chain is too big");
-    memcpy((char *) (0xF4120000), second_chain, sizeof(second_chain));
-    static_assert(sizeof(final_chain) < 0xF4140000 - 0xF4130000, "second_chain is too big");
-    memcpy((char *) (0xF4130000), final_chain, sizeof(final_chain));
-    static_assert(sizeof(final_chain) < 0xF4148000 - 0xF4140000, "ios_kernel is too big");
-    memcpy((char *) (0xF4140000), ios_kernel, sizeof(ios_kernel));
-
+static void copy_payloads(void){
     static_assert(sizeof(ios_usb) < 0xF4149000 - 0xF4148000, "IOS_USB is too big");
     payload_info_t *payloads = (payload_info_t *) 0xF4148000;
     payloads->size           = sizeof(ios_usb);
@@ -336,6 +327,21 @@ static void uhs_exploit_init(int dev_uhs_0_handle) {
     payloads       = (payload_info_t *) 0xF4170000;
     payloads->size = sizeof(ios_fs);
     memcpy(payloads->data, ios_fs, payloads->size);
+    DCStoreRange((void *) 0xF4148000, ((uint32_t) 0xF4180000) - 0xF4148000);
+}
+
+static void uhs_exploit_init(int dev_uhs_0_handle) {
+    ayylmao[5] = 1;
+    ayylmao[8] = 0x500000;
+
+    static_assert(sizeof(second_chain) < 0xF4130000 - 0xF4120000, "second_chain is too big");
+    memcpy((char *) (0xF4120000), second_chain, sizeof(second_chain));
+    static_assert(sizeof(final_chain) < 0xF4140000 - 0xF4130000, "second_chain is too big");
+    memcpy((char *) (0xF4130000), final_chain, sizeof(final_chain));
+    static_assert(sizeof(final_chain) < 0xF4148000 - 0xF4140000, "ios_kernel is too big");
+    memcpy((char *) (0xF4140000), ios_kernel, sizeof(ios_kernel));
+
+    copy_payloads();
 
     pretend_root_hub[33] = 0x500000;
     pretend_root_hub[78] = 0;
@@ -378,19 +384,59 @@ int ExecuteIOSExploit() {
         return 0;
     }
 
-    //! execute exploit
-    int dev_uhs_0_handle = IOS_Open("/dev/uhs/0", 0);
-    if (dev_uhs_0_handle < 0) {
-        return dev_uhs_0_handle;
+    StroopwafelWrite payload_infos[] = {
+        {
+            .dest_addr = ARM_CODE_BASE,
+            .src = ios_kernel,
+            .length = sizeof(ios_kernel) 
+        },
+        // {
+        //     .dest_addr = 0x101312D0,
+        //     .src = ios_usb,
+        //     .length = sizeof(ios_usb) 
+        // },
+        // {
+        //     .dest_addr = 0x12431900,
+        //     .src = ios_net,
+        //     .length = sizeof(ios_net)
+        // },
+        // {
+        //     .dest_addr = 0x05116000,
+        //     .src = ios_mcp,
+        //     .length = sizeof(ios_mcp)
+        // },
+        // {
+        //     .dest_addr = 0x107F8200,
+        //     .src = ios_fs,
+        //     .length = sizeof(ios_fs)
+        // }
+    };
+
+    int num_payloads = sizeof(payload_infos) / sizeof(StroopwafelWrite);
+    for(int i=0; i< num_payloads; i++){
+        void *buff = memalign(64, payload_infos[i].length);
+        memcpy(buff, payload_infos[i].src, payload_infos[i].length);
+        payload_infos[i].src = buff;
     }
 
-    uhs_exploit_init(dev_uhs_0_handle);
-    uhs_write32(dev_uhs_0_handle, CHAIN_START + 0x14, CHAIN_START + 0x14 + 0x4 + 0x20);
-    uhs_write32(dev_uhs_0_handle, CHAIN_START + 0x10, 0x1011814C);
-    uhs_write32(dev_uhs_0_handle, CHAIN_START + 0xC, SOURCE);
+    Stroopwafel_WriteMemory(sizeof(payload_infos) / sizeof(StroopwafelWrite), payload_infos);
+    copy_payloads();
+    OSSleepTicks(0x200000);                   //!  Improves stability
+    Stroopwafel_Execute(ARM_CODE_BASE, NULL, 0, NULL, 0);
 
-    uhs_write32(dev_uhs_0_handle, CHAIN_START, 0x1012392b); // pop {R4-R6,PC}
+    //! execute exploit
+    // int dev_uhs_0_handle = IOS_Open("/dev/uhs/0", 0);
+    // if (dev_uhs_0_handle < 0) {
+    //     return dev_uhs_0_handle;
+    // }
 
-    IOS_Close(dev_uhs_0_handle);
+    // uhs_exploit_init(dev_uhs_0_handle);
+    // uhs_write32(dev_uhs_0_handle, CHAIN_START + 0x14, CHAIN_START + 0x14 + 0x4 + 0x20);
+    // uhs_write32(dev_uhs_0_handle, CHAIN_START + 0x10, 0x1011814C);
+    // uhs_write32(dev_uhs_0_handle, CHAIN_START + 0xC, SOURCE);
+
+    // uhs_write32(dev_uhs_0_handle, CHAIN_START, 0x1012392b); // pop {R4-R6,PC}
+
+    // IOS_Close(dev_uhs_0_handle);
     return 0;
 }

--- a/source/ios_exploit.c
+++ b/source/ios_exploit.c
@@ -6,6 +6,7 @@
 #include <stdint.h>
 #include <stdlib.h>
 #include <string.h>
+#include <malloc.h>
 #include <stroopwafel/stroopwafel.h>
 
 #define ALIGN4(x)        (((x) + 3) & ~3)

--- a/source/ios_exploit.c
+++ b/source/ios_exploit.c
@@ -1,4 +1,5 @@
 #include "ios_exploit.h"
+#include "ios_kernel/source/instant_patches_common.h"
 #include <coreinit/cache.h>
 #include <coreinit/ios.h>
 #include <coreinit/thread.h>
@@ -6,7 +7,6 @@
 #include <stdlib.h>
 #include <string.h>
 #include <stroopwafel/stroopwafel.h>
-#include "ios_kernel/source/instant_patches_common.h"
 
 #define ALIGN4(x)        (((x) + 3) & ~3)
 
@@ -360,7 +360,7 @@ static int uhs_write32(int dev_uhs_0_handle, int arm_addr, int val) {
     return IOS_Ioctl(dev_uhs_0_handle, 0x15, request_buffer, sizeof(request_buffer), output_buffer, sizeof(output_buffer));
 }
 
-static int use_exploit(){
+static int use_exploit() {
     //! execute exploit
     int dev_uhs_0_handle = IOS_Open("/dev/uhs/0", 0);
     if (dev_uhs_0_handle < 0) {
@@ -378,7 +378,7 @@ static int use_exploit(){
     return 0;
 }
 
-static int use_stroopwafel(){
+static int use_stroopwafel() {
     int res;
     StroopwafelMapMemory map_info;
     map_info.paddr  = mcp_custom_bss_phys(MCP_CUSTOM_BSS_START);
@@ -387,8 +387,8 @@ static int use_stroopwafel(){
     map_info.domain = 1; // MCP
     map_info.type   = 3; // 0 = undefined, 1 = kernel only, 2 = read only, 3 = read/write
     map_info.cached = 0xFFFFFFFF;
-    res = Stroopwafel_MapMemory(&map_info); // actually a bss section but oh well it will have read/write
-    if(res!=STROOPWAFEL_RESULT_SUCCESS)
+    res             = Stroopwafel_MapMemory(&map_info); // actually a bss section but oh well it will have read/write
+    if (res != STROOPWAFEL_RESULT_SUCCESS)
         return res;
 
     map_info.paddr  = mcp_custom_text_phys(MCP_CUSTOM_TEXT_START);
@@ -397,53 +397,42 @@ static int use_stroopwafel(){
     map_info.domain = 1; // MCP
     map_info.type   = 3; // 0 = undefined, 1 = kernel only, 2 = read only, 3 = read write
     map_info.cached = 0xFFFFFFFF;
-    res = Stroopwafel_MapMemory(&map_info);
-    if(res!=STROOPWAFEL_RESULT_SUCCESS)
+    res             = Stroopwafel_MapMemory(&map_info);
+    if (res != STROOPWAFEL_RESULT_SUCCESS)
         return res;
 
     StroopwafelWrite payload_infos[] = {
-        {
-            .dest_addr = ARM_CODE_BASE,
-            .src = ios_kernel,
-            .length = sizeof(ios_kernel) 
-        },
-        {
-            .dest_addr = 0x101312D0,
-            .src = ios_usb,
-            .length = sizeof(ios_usb) 
-        },
-        {
-            .dest_addr = 0x12431900,
-            .src = ios_net,
-            .length = sizeof(ios_net)
-        },
-        {
-            .dest_addr = 0x05116000,
-            .src = ios_mcp,
-            .length = sizeof(ios_mcp)
-        },
-        {
-            .dest_addr = 0x107F8200,
-            .src = ios_fs,
-            .length = sizeof(ios_fs)
-        }
-    };
+            {.dest_addr = ARM_CODE_BASE,
+             .src       = ios_kernel,
+             .length    = sizeof(ios_kernel)},
+            {.dest_addr = 0x101312D0,
+             .src       = ios_usb,
+             .length    = sizeof(ios_usb)},
+            {.dest_addr = 0x12431900,
+             .src       = ios_net,
+             .length    = sizeof(ios_net)},
+            {.dest_addr = 0x05116000,
+             .src       = ios_mcp,
+             .length    = sizeof(ios_mcp)},
+            {.dest_addr = 0x107F8200,
+             .src       = ios_fs,
+             .length    = sizeof(ios_fs)}};
 
     int num_payloads = sizeof(payload_infos) / sizeof(StroopwafelWrite);
-    for(int i=0; i< num_payloads; i++){
+    for (int i = 0; i < num_payloads; i++) {
         void *buff = memalign(64, payload_infos[i].length);
         memcpy(buff, payload_infos[i].src, payload_infos[i].length);
         payload_infos[i].src = buff;
     }
 
     // MOV R0, #1 to signal launched from stroopwafel
-    *((uint32_t*)payload_infos[0].src) = 0xe3a00001;
+    *((uint32_t *) payload_infos[0].src) = 0xe3a00001;
 
     res = Stroopwafel_WriteMemory(sizeof(payload_infos) / sizeof(StroopwafelWrite), payload_infos);
-    if(res!=STROOPWAFEL_RESULT_SUCCESS)
+    if (res != STROOPWAFEL_RESULT_SUCCESS)
         return res;
     //copy_payloads();
-    OSSleepTicks(0x200000);                   //!  Improves stability
+    OSSleepTicks(0x200000); //!  Improves stability
     res = Stroopwafel_Execute(ARM_CODE_BASE, NULL, 0, NULL, 0);
     return res;
 }
@@ -470,13 +459,12 @@ int ExecuteIOSExploit() {
         return 0;
     }
 
-    if(Stroopwafel_InitLibrary() == STROOPWAFEL_RESULT_SUCCESS){
+    if (Stroopwafel_InitLibrary() == STROOPWAFEL_RESULT_SUCCESS) {
         int res = use_stroopwafel();
         Stroopwafel_DeInitLibrary();
-        if(res == STROOPWAFEL_RESULT_SUCCESS)
+        if (res == STROOPWAFEL_RESULT_SUCCESS)
             return res;
     }
-      
-    return use_exploit();
 
+    return use_exploit();
 }

--- a/source/ios_exploit.c
+++ b/source/ios_exploit.c
@@ -309,7 +309,17 @@ static const int second_chain[] = {
         0x1012EA68, // 0xAC         stack pivot
 };
 
-static void copy_payloads(void){
+static void uhs_exploit_init(int dev_uhs_0_handle) {
+    ayylmao[5] = 1;
+    ayylmao[8] = 0x500000;
+
+    static_assert(sizeof(second_chain) < 0xF4130000 - 0xF4120000, "second_chain is too big");
+    memcpy((char *) (0xF4120000), second_chain, sizeof(second_chain));
+    static_assert(sizeof(final_chain) < 0xF4140000 - 0xF4130000, "second_chain is too big");
+    memcpy((char *) (0xF4130000), final_chain, sizeof(final_chain));
+    static_assert(sizeof(final_chain) < 0xF4148000 - 0xF4140000, "ios_kernel is too big");
+    memcpy((char *) (0xF4140000), ios_kernel, sizeof(ios_kernel));
+
     static_assert(sizeof(ios_usb) < 0xF4149000 - 0xF4148000, "IOS_USB is too big");
     payload_info_t *payloads = (payload_info_t *) 0xF4148000;
     payloads->size           = sizeof(ios_usb);
@@ -330,20 +340,6 @@ static void copy_payloads(void){
     payloads->size = sizeof(ios_fs);
     memcpy(payloads->data, ios_fs, payloads->size);
     DCStoreRange((void *) 0xF4148000, ((uint32_t) 0xF4180000) - 0xF4148000);
-}
-
-static void uhs_exploit_init(int dev_uhs_0_handle) {
-    ayylmao[5] = 1;
-    ayylmao[8] = 0x500000;
-
-    static_assert(sizeof(second_chain) < 0xF4130000 - 0xF4120000, "second_chain is too big");
-    memcpy((char *) (0xF4120000), second_chain, sizeof(second_chain));
-    static_assert(sizeof(final_chain) < 0xF4140000 - 0xF4130000, "second_chain is too big");
-    memcpy((char *) (0xF4130000), final_chain, sizeof(final_chain));
-    static_assert(sizeof(final_chain) < 0xF4148000 - 0xF4140000, "ios_kernel is too big");
-    memcpy((char *) (0xF4140000), ios_kernel, sizeof(ios_kernel));
-
-    copy_payloads();
 
     pretend_root_hub[33] = 0x500000;
     pretend_root_hub[78] = 0;
@@ -364,29 +360,26 @@ static int uhs_write32(int dev_uhs_0_handle, int arm_addr, int val) {
     return IOS_Ioctl(dev_uhs_0_handle, 0x15, request_buffer, sizeof(request_buffer), output_buffer, sizeof(output_buffer));
 }
 
-int ExecuteIOSExploit() {
-    int iosuhaxFd = IOS_Open("/dev/iosuhax", 0);
-    if (iosuhaxFd >= 0) {
-
-        // Write default title id.
-        int dummy[2];
-
-        dummy[0] = 0x050B817C;
-        dummy[1] = *((uint32_t *) 0xF417FFF0);
-        IOS_Ioctl(iosuhaxFd, 0x07, &dummy, sizeof(dummy), &dummy, sizeof(dummy)); // IOCTL_KERN_WRITE32
-
-        dummy[0] = 0x050B8180;
-        dummy[1] = *((uint32_t *) 0xF417FFF4);
-        IOS_Ioctl(iosuhaxFd, 0x07, &dummy, sizeof(dummy), &dummy, sizeof(dummy)); // IOCTL_KERN_WRITE32
-
-        //! do not run patches again as that will most likely crash
-        //! because the wupserver and the iosuhax dev node are still running
-        //! just relaunch IOS with new configuration
-        IOS_Close(iosuhaxFd);
-        return 0;
+static int use_exploit(){
+    //! execute exploit
+    int dev_uhs_0_handle = IOS_Open("/dev/uhs/0", 0);
+    if (dev_uhs_0_handle < 0) {
+        return dev_uhs_0_handle;
     }
 
-    
+    uhs_exploit_init(dev_uhs_0_handle);
+    uhs_write32(dev_uhs_0_handle, CHAIN_START + 0x14, CHAIN_START + 0x14 + 0x4 + 0x20);
+    uhs_write32(dev_uhs_0_handle, CHAIN_START + 0x10, 0x1011814C);
+    uhs_write32(dev_uhs_0_handle, CHAIN_START + 0xC, SOURCE);
+
+    uhs_write32(dev_uhs_0_handle, CHAIN_START, 0x1012392b); // pop {R4-R6,PC}
+
+    IOS_Close(dev_uhs_0_handle);
+    return 0;
+}
+
+static int use_stroopwafel(){
+    int res;
     StroopwafelMapMemory map_info;
     map_info.paddr  = mcp_custom_bss_phys(MCP_CUSTOM_BSS_START);
     map_info.vaddr  = MCP_CUSTOM_BSS_START;
@@ -394,7 +387,9 @@ int ExecuteIOSExploit() {
     map_info.domain = 1; // MCP
     map_info.type   = 3; // 0 = undefined, 1 = kernel only, 2 = read only, 3 = read/write
     map_info.cached = 0xFFFFFFFF;
-    Stroopwafel_MapMemory(&map_info); // actually a bss section but oh well it will have read/write
+    res = Stroopwafel_MapMemory(&map_info); // actually a bss section but oh well it will have read/write
+    if(res!=STROOPWAFEL_RESULT_SUCCESS)
+        return res;
 
     map_info.paddr  = mcp_custom_text_phys(MCP_CUSTOM_TEXT_START);
     map_info.vaddr  = MCP_CUSTOM_TEXT_START;
@@ -402,8 +397,9 @@ int ExecuteIOSExploit() {
     map_info.domain = 1; // MCP
     map_info.type   = 3; // 0 = undefined, 1 = kernel only, 2 = read only, 3 = read write
     map_info.cached = 0xFFFFFFFF;
-    Stroopwafel_MapMemory(&map_info);
-
+    res = Stroopwafel_MapMemory(&map_info);
+    if(res!=STROOPWAFEL_RESULT_SUCCESS)
+        return res;
 
     StroopwafelWrite payload_infos[] = {
         {
@@ -440,26 +436,47 @@ int ExecuteIOSExploit() {
         payload_infos[i].src = buff;
     }
 
-    //((uint32_t*)payload_infos[0].src)[1] = 1;
+    // MOV R0, #1 to signal launched from stroopwafel
+    *((uint32_t*)payload_infos[0].src) = 0xe3a00001;
 
-    Stroopwafel_WriteMemory(sizeof(payload_infos) / sizeof(StroopwafelWrite), payload_infos);
+    res = Stroopwafel_WriteMemory(sizeof(payload_infos) / sizeof(StroopwafelWrite), payload_infos);
+    if(res!=STROOPWAFEL_RESULT_SUCCESS)
+        return res;
     //copy_payloads();
     OSSleepTicks(0x200000);                   //!  Improves stability
-    Stroopwafel_Execute(ARM_CODE_BASE, NULL, 0, NULL, 0);
+    res = Stroopwafel_Execute(ARM_CODE_BASE, NULL, 0, NULL, 0);
+    return res;
+}
 
-    //! execute exploit
-    // int dev_uhs_0_handle = IOS_Open("/dev/uhs/0", 0);
-    // if (dev_uhs_0_handle < 0) {
-    //     return dev_uhs_0_handle;
-    // }
+int ExecuteIOSExploit() {
+    int iosuhaxFd = IOS_Open("/dev/iosuhax", 0);
+    if (iosuhaxFd >= 0) {
 
-    // uhs_exploit_init(dev_uhs_0_handle);
-    // uhs_write32(dev_uhs_0_handle, CHAIN_START + 0x14, CHAIN_START + 0x14 + 0x4 + 0x20);
-    // uhs_write32(dev_uhs_0_handle, CHAIN_START + 0x10, 0x1011814C);
-    // uhs_write32(dev_uhs_0_handle, CHAIN_START + 0xC, SOURCE);
+        // Write default title id.
+        int dummy[2];
 
-    // uhs_write32(dev_uhs_0_handle, CHAIN_START, 0x1012392b); // pop {R4-R6,PC}
+        dummy[0] = 0x050B817C;
+        dummy[1] = *((uint32_t *) 0xF417FFF0);
+        IOS_Ioctl(iosuhaxFd, 0x07, &dummy, sizeof(dummy), &dummy, sizeof(dummy)); // IOCTL_KERN_WRITE32
 
-    // IOS_Close(dev_uhs_0_handle);
-    return 0;
+        dummy[0] = 0x050B8180;
+        dummy[1] = *((uint32_t *) 0xF417FFF4);
+        IOS_Ioctl(iosuhaxFd, 0x07, &dummy, sizeof(dummy), &dummy, sizeof(dummy)); // IOCTL_KERN_WRITE32
+
+        //! do not run patches again as that will most likely crash
+        //! because the wupserver and the iosuhax dev node are still running
+        //! just relaunch IOS with new configuration
+        IOS_Close(iosuhaxFd);
+        return 0;
+    }
+
+    if(Stroopwafel_InitLibrary() == STROOPWAFEL_RESULT_SUCCESS){
+        int res = use_stroopwafel();
+        Stroopwafel_DeInitLibrary();
+        if(res == STROOPWAFEL_RESULT_SUCCESS)
+            return res;
+    }
+      
+    return use_exploit();
+
 }

--- a/source/ios_exploit.c
+++ b/source/ios_exploit.c
@@ -3,8 +3,10 @@
 #include <coreinit/ios.h>
 #include <coreinit/thread.h>
 #include <stdint.h>
+#include <stdlib.h>
 #include <string.h>
 #include <stroopwafel/stroopwafel.h>
+#include "ios_kernel/source/instant_patches_common.h"
 
 #define ALIGN4(x)        (((x) + 3) & ~3)
 
@@ -384,32 +386,51 @@ int ExecuteIOSExploit() {
         return 0;
     }
 
+    
+    StroopwafelMapMemory map_info;
+    map_info.paddr  = mcp_custom_bss_phys(MCP_CUSTOM_BSS_START);
+    map_info.vaddr  = MCP_CUSTOM_BSS_START;
+    map_info.size   = MCP_CUSTOM_BSS_LENGTH;
+    map_info.domain = 1; // MCP
+    map_info.type   = 3; // 0 = undefined, 1 = kernel only, 2 = read only, 3 = read/write
+    map_info.cached = 0xFFFFFFFF;
+    Stroopwafel_MapMemory(&map_info); // actually a bss section but oh well it will have read/write
+
+    map_info.paddr  = mcp_custom_text_phys(MCP_CUSTOM_TEXT_START);
+    map_info.vaddr  = MCP_CUSTOM_TEXT_START;
+    map_info.size   = MCP_CUSTOM_TEXT_LENGTH;
+    map_info.domain = 1; // MCP
+    map_info.type   = 3; // 0 = undefined, 1 = kernel only, 2 = read only, 3 = read write
+    map_info.cached = 0xFFFFFFFF;
+    Stroopwafel_MapMemory(&map_info);
+
+
     StroopwafelWrite payload_infos[] = {
         {
             .dest_addr = ARM_CODE_BASE,
             .src = ios_kernel,
             .length = sizeof(ios_kernel) 
         },
-        // {
-        //     .dest_addr = 0x101312D0,
-        //     .src = ios_usb,
-        //     .length = sizeof(ios_usb) 
-        // },
-        // {
-        //     .dest_addr = 0x12431900,
-        //     .src = ios_net,
-        //     .length = sizeof(ios_net)
-        // },
-        // {
-        //     .dest_addr = 0x05116000,
-        //     .src = ios_mcp,
-        //     .length = sizeof(ios_mcp)
-        // },
-        // {
-        //     .dest_addr = 0x107F8200,
-        //     .src = ios_fs,
-        //     .length = sizeof(ios_fs)
-        // }
+        {
+            .dest_addr = 0x101312D0,
+            .src = ios_usb,
+            .length = sizeof(ios_usb) 
+        },
+        {
+            .dest_addr = 0x12431900,
+            .src = ios_net,
+            .length = sizeof(ios_net)
+        },
+        {
+            .dest_addr = 0x05116000,
+            .src = ios_mcp,
+            .length = sizeof(ios_mcp)
+        },
+        {
+            .dest_addr = 0x107F8200,
+            .src = ios_fs,
+            .length = sizeof(ios_fs)
+        }
     };
 
     int num_payloads = sizeof(payload_infos) / sizeof(StroopwafelWrite);
@@ -419,8 +440,10 @@ int ExecuteIOSExploit() {
         payload_infos[i].src = buff;
     }
 
+    //((uint32_t*)payload_infos[0].src)[1] = 1;
+
     Stroopwafel_WriteMemory(sizeof(payload_infos) / sizeof(StroopwafelWrite), payload_infos);
-    copy_payloads();
+    //copy_payloads();
     OSSleepTicks(0x200000);                   //!  Improves stability
     Stroopwafel_Execute(ARM_CODE_BASE, NULL, 0, NULL, 0);
 

--- a/source/ios_exploit.c
+++ b/source/ios_exploit.c
@@ -3,10 +3,10 @@
 #include <coreinit/cache.h>
 #include <coreinit/ios.h>
 #include <coreinit/thread.h>
+#include <malloc.h>
 #include <stdint.h>
 #include <stdlib.h>
 #include <string.h>
-#include <malloc.h>
 #include <stroopwafel/stroopwafel.h>
 
 #define ALIGN4(x)        (((x) + 3) & ~3)

--- a/source/ios_kernel/source/crt0.s
+++ b/source/ios_kernel/source/crt0.s
@@ -6,4 +6,5 @@
 .type _main, %function
 
 _start:
+	mov r0, #0
 	b _main

--- a/source/ios_kernel/source/elf_patcher.c
+++ b/source/ios_kernel/source/elf_patcher.c
@@ -67,8 +67,7 @@ void section_write(u32 ios_elf_start, u32 address, const void *data, u32 size) {
 
         Elf32_Ehdr *ehdr = (Elf32_Ehdr *) ios_elf_start;
         Elf32_Phdr *tmpPhdr;
-        u32 i;
-        for (i = (ehdr->e_phnum - 1); i >= 0; i--) {
+        for (s32 i = (ehdr->e_phnum - 1); i >= 0; i--) {
             tmpPhdr = (Elf32_Phdr *) (ios_elf_start + ehdr->e_phoff + ehdr->e_phentsize * i);
 
             if (phdr->p_offset < tmpPhdr->p_offset) {

--- a/source/ios_kernel/source/instant_patches.c
+++ b/source/ios_kernel/source/instant_patches.c
@@ -25,6 +25,7 @@
 #include "../../ios_mcp/ios_mcp_syms.h"
 #include "../../ios_net/ios_net_syms.h"
 #include "elf_patcher.h"
+#include "instant_patches_common.h"
 #include "ios_fs_patches.h"
 #include "kernel_patches.h"
 #include "types.h"
@@ -38,10 +39,6 @@ typedef struct {
     u32 type;
     u32 cached;
 } ios_map_shared_info_t;
-#define MCP_CUSTOM_TEXT_LENGTH     0xA000
-#define MCP_CUSTOM_TEXT_START      0x05116000
-#define MCP_CUSTOM_BSS_START       0x050BD000
-#define MCP_CUSTOM_BSS_LENGTH      0x3000
 #define ENVIRONMENT_PATH_LENGTH    0x100
 
 #define mcp_text_phys(addr)        ((u32) (addr) -0x05000000 + 0x081C0000)
@@ -54,10 +51,8 @@ typedef struct {
 #define nimboss_text_phys(addr)    ((u32) (addr) -0xe2000000 + 0x12EC0000)
 #define nimboss_rodata_phys(addr)  ((u32) (addr) -0xe2280000 + 0x13140000)
 #define bsp_data_phys(addr)        ((u32) (addr) -0xe6042000 + 0x13d02000)
-#define mcp_custom_text_phys(addr) ((u32) (addr) -0x05100000 + 0x13D80000)
-#define mcp_custom_bss_phys(addr)  ((u32) (addr) -0x05000000 + 0x081C0000)
 
-void instant_patches_setup(void) {
+void instant_patches_setup(u32 stroopwafel) {
     // apply IOS ELF launch hook
     *(volatile u32 *) 0x0812A120 = ARM_BL(0x0812A120, kernel_launch_ios);
 
@@ -227,20 +222,22 @@ void instant_patches_setup(void) {
     // Patch MCP to syslog everything
     *(volatile u32 *) mcp_text_phys(0x05055438) = ARM_B(0x05055438, 0x0503dcf8);
 
-    ios_map_shared_info_t map_info;
-    map_info.paddr  = mcp_custom_bss_phys(MCP_CUSTOM_BSS_START);
-    map_info.vaddr  = MCP_CUSTOM_BSS_START;
-    map_info.size   = MCP_CUSTOM_BSS_LENGTH;
-    map_info.domain = 1; // MCP
-    map_info.type   = 3; // 0 = undefined, 1 = kernel only, 2 = read only, 3 = read/write
-    map_info.cached = 0xFFFFFFFF;
-    _iosMapSharedUserExecution(&map_info); // actually a bss section but oh well it will have read/write
+    if(!stroopwafel) {
+        ios_map_shared_info_t map_info;
+        map_info.paddr  = mcp_custom_bss_phys(MCP_CUSTOM_BSS_START);
+        map_info.vaddr  = MCP_CUSTOM_BSS_START;
+        map_info.size   = MCP_CUSTOM_BSS_LENGTH;
+        map_info.domain = 1; // MCP
+        map_info.type   = 3; // 0 = undefined, 1 = kernel only, 2 = read only, 3 = read/write
+        map_info.cached = 0xFFFFFFFF;
+        _iosMapSharedUserExecution(&map_info); // actually a bss section but oh well it will have read/write
 
-    map_info.paddr  = mcp_custom_text_phys(MCP_CUSTOM_TEXT_START);
-    map_info.vaddr  = MCP_CUSTOM_TEXT_START;
-    map_info.size   = MCP_CUSTOM_TEXT_LENGTH;
-    map_info.domain = 1; // MCP
-    map_info.type   = 3; // 0 = undefined, 1 = kernel only, 2 = read only, 3 = read write
-    map_info.cached = 0xFFFFFFFF;
-    _iosMapSharedUserExecution(&map_info);
+        map_info.paddr  = mcp_custom_text_phys(MCP_CUSTOM_TEXT_START);
+        map_info.vaddr  = MCP_CUSTOM_TEXT_START;
+        map_info.size   = MCP_CUSTOM_TEXT_LENGTH;
+        map_info.domain = 1; // MCP
+        map_info.type   = 3; // 0 = undefined, 1 = kernel only, 2 = read only, 3 = read write
+        map_info.cached = 0xFFFFFFFF;
+        _iosMapSharedUserExecution(&map_info);
+    }
 }

--- a/source/ios_kernel/source/instant_patches.c
+++ b/source/ios_kernel/source/instant_patches.c
@@ -39,18 +39,18 @@ typedef struct {
     u32 type;
     u32 cached;
 } ios_map_shared_info_t;
-#define ENVIRONMENT_PATH_LENGTH    0x100
+#define ENVIRONMENT_PATH_LENGTH   0x100
 
-#define mcp_text_phys(addr)        ((u32) (addr) -0x05000000 + 0x081C0000)
-#define mcp_rodata_phys(addr)      ((u32) (addr) -0x05060000 + 0x08220000)
-#define mcp_data_phys(addr)        ((u32) (addr) -0x05074000 + 0x08234000)
-#define net_phys(addr)             ((u32) (addr))
-#define fsa_phys(addr)             ((u32) (addr))
-#define kernel_phys(addr)          ((u32) (addr))
-#define acp_text_phys(addr)        ((u32) (addr) -0xE0000000 + 0x12900000)
-#define nimboss_text_phys(addr)    ((u32) (addr) -0xe2000000 + 0x12EC0000)
-#define nimboss_rodata_phys(addr)  ((u32) (addr) -0xe2280000 + 0x13140000)
-#define bsp_data_phys(addr)        ((u32) (addr) -0xe6042000 + 0x13d02000)
+#define mcp_text_phys(addr)       ((u32) (addr) -0x05000000 + 0x081C0000)
+#define mcp_rodata_phys(addr)     ((u32) (addr) -0x05060000 + 0x08220000)
+#define mcp_data_phys(addr)       ((u32) (addr) -0x05074000 + 0x08234000)
+#define net_phys(addr)            ((u32) (addr))
+#define fsa_phys(addr)            ((u32) (addr))
+#define kernel_phys(addr)         ((u32) (addr))
+#define acp_text_phys(addr)       ((u32) (addr) -0xE0000000 + 0x12900000)
+#define nimboss_text_phys(addr)   ((u32) (addr) -0xe2000000 + 0x12EC0000)
+#define nimboss_rodata_phys(addr) ((u32) (addr) -0xe2280000 + 0x13140000)
+#define bsp_data_phys(addr)       ((u32) (addr) -0xe6042000 + 0x13d02000)
 
 void instant_patches_setup(u32 stroopwafel) {
     // apply IOS ELF launch hook
@@ -222,7 +222,7 @@ void instant_patches_setup(u32 stroopwafel) {
     // Patch MCP to syslog everything
     *(volatile u32 *) mcp_text_phys(0x05055438) = ARM_B(0x05055438, 0x0503dcf8);
 
-    if(!stroopwafel) {
+    if (!stroopwafel) {
         ios_map_shared_info_t map_info;
         map_info.paddr  = mcp_custom_bss_phys(MCP_CUSTOM_BSS_START);
         map_info.vaddr  = MCP_CUSTOM_BSS_START;

--- a/source/ios_kernel/source/instant_patches.c
+++ b/source/ios_kernel/source/instant_patches.c
@@ -22,8 +22,20 @@
  * distribution.
  ***************************************************************************/
 #include "../../ios_fs/ios_fs_syms.h"
+#undef _text_start
+#undef _text_end
+#undef _bss_start
+#undef _bss_end
 #include "../../ios_mcp/ios_mcp_syms.h"
+#undef _text_start
+#undef _text_end
+#undef _bss_start
+#undef _bss_end
 #include "../../ios_net/ios_net_syms.h"
+#undef _text_start
+#undef _text_end
+#undef _bss_start
+#undef _bss_end
 #include "elf_patcher.h"
 #include "instant_patches_common.h"
 #include "ios_fs_patches.h"

--- a/source/ios_kernel/source/instant_patches.c
+++ b/source/ios_kernel/source/instant_patches.c
@@ -53,8 +53,22 @@ typedef struct {
 #define bsp_data_phys(addr)       ((u32) (addr) -0xe6042000 + 0x13d02000)
 
 void instant_patches_setup(u32 stroopwafel) {
-    // apply IOS ELF launch hook
-    *(volatile u32 *) 0x0812A120 = ARM_BL(0x0812A120, kernel_launch_ios);
+
+    if (!stroopwafel) {
+        // stroopwafel already hooks the reload and goes trough minute
+        // apply IOS ELF launch hook
+        *(volatile u32 *) 0x0812A120 = ARM_BL(0x0812A120, kernel_launch_ios);
+
+        // patches already applied by stroopwafel
+        // fix 10 minute timeout that crashes MCP after 10 minutes of booting
+        *(volatile u32 *) mcp_text_phys(0x05022474) = 0xFFFFFFFF; // NEW_TIMEOUT
+
+        // Patch FS to syslog everything
+        *(volatile u32 *) fsa_phys(0x107F5720) = ARM_B(0x107F5720, 0x107F0C84);
+
+        // Patch MCP to syslog everything
+        *(volatile u32 *) mcp_text_phys(0x05055438) = ARM_B(0x05055438, 0x0503dcf8);
+    }
 
     *(volatile u32 *) 0x0812CD2C = ARM_B(0x0812CD2C, kernel_syscall_0x81);
 
@@ -124,13 +138,8 @@ void instant_patches_setup(u32 stroopwafel) {
         }
     }
 
-    int (*_iosMapSharedUserExecution)(void *descr) = (void *) 0x08124F88;
-
     // patch kernel dev node registration
     *(volatile u32 *) kernel_phys(0x081430B4) = 1;
-
-    // fix 10 minute timeout that crashes MCP after 10 minutes of booting
-    *(volatile u32 *) mcp_text_phys(0x05022474) = 0xFFFFFFFF; // NEW_TIMEOUT
 
     kernel_memset((void *) mcp_custom_bss_phys(0x050BD000), 0, MCP_CUSTOM_BSS_LENGTH);
 
@@ -216,13 +225,9 @@ void instant_patches_setup(u32 stroopwafel) {
     // force check USB storage on load
     *(volatile u32 *) acp_text_phys(0xE012202C) = 0x00000001; // find USB flag
 
-    // Patch FS to syslog everything
-    *(volatile u32 *) fsa_phys(0x107F5720) = ARM_B(0x107F5720, 0x107F0C84);
-
-    // Patch MCP to syslog everything
-    *(volatile u32 *) mcp_text_phys(0x05055438) = ARM_B(0x05055438, 0x0503dcf8);
-
     if (!stroopwafel) {
+        // Memory was already mapped via stroopwafel
+        int (*_iosMapSharedUserExecution)(void *descr) = (void *) 0x08124F88;
         ios_map_shared_info_t map_info;
         map_info.paddr  = mcp_custom_bss_phys(MCP_CUSTOM_BSS_START);
         map_info.vaddr  = MCP_CUSTOM_BSS_START;

--- a/source/ios_kernel/source/instant_patches.h
+++ b/source/ios_kernel/source/instant_patches.h
@@ -24,6 +24,8 @@
 #ifndef _INSTANT_PATCHES_SETUP_H_
 #define _INSTANT_PATCHES_SETUP_H_
 
-void instant_patches_setup(void);
+#include "types.h"
+
+void instant_patches_setup(u32 stroopwafel);
 
 #endif

--- a/source/ios_kernel/source/instant_patches_common.h
+++ b/source/ios_kernel/source/instant_patches_common.h
@@ -3,11 +3,11 @@
 
 #include "types.h"
 
-#define MCP_CUSTOM_TEXT_LENGTH 0xA000
-#define MCP_CUSTOM_TEXT_START 0x05116000
-#define MCP_CUSTOM_BSS_START 0x050BD000
-#define MCP_CUSTOM_BSS_LENGTH 0x3000
-#define mcp_custom_text_phys(addr) ((u32)(addr)-0x05100000 + 0x13D80000)
-#define mcp_custom_bss_phys(addr) ((u32)(addr)-0x05000000 + 0x081C0000)
+#define MCP_CUSTOM_TEXT_LENGTH     0xA000
+#define MCP_CUSTOM_TEXT_START      0x05116000
+#define MCP_CUSTOM_BSS_START       0x050BD000
+#define MCP_CUSTOM_BSS_LENGTH      0x3000
+#define mcp_custom_text_phys(addr) ((u32) (addr) -0x05100000 + 0x13D80000)
+#define mcp_custom_bss_phys(addr)  ((u32) (addr) -0x05000000 + 0x081C0000)
 
 #endif

--- a/source/ios_kernel/source/instant_patches_common.h
+++ b/source/ios_kernel/source/instant_patches_common.h
@@ -1,0 +1,13 @@
+#ifndef _INSTANT_PATCHES_COMMON_H_
+#define _INSTANT_PATCHES_COMMON_H_
+
+#include "types.h"
+
+#define MCP_CUSTOM_TEXT_LENGTH 0xA000
+#define MCP_CUSTOM_TEXT_START 0x05116000
+#define MCP_CUSTOM_BSS_START 0x050BD000
+#define MCP_CUSTOM_BSS_LENGTH 0x3000
+#define mcp_custom_text_phys(addr) ((u32)(addr)-0x05100000 + 0x13D80000)
+#define mcp_custom_bss_phys(addr) ((u32)(addr)-0x05000000 + 0x081C0000)
+
+#endif

--- a/source/ios_kernel/source/kernel_patches.c
+++ b/source/ios_kernel/source/kernel_patches.c
@@ -69,7 +69,7 @@ int kernel_syscall_0x81(u32 command, u32 arg1, u32 arg2, u32 arg3) {
             break;
         }
         case KERNEL_WRITE32: {
-            kernel_memcpy((void*)arg1, &arg2, sizeof(uint32_t));
+            kernel_memcpy((void *) arg1, &arg2, sizeof(uint32_t));
             flush_dcache(arg1, 4);
             invalidate_icache();
             break;

--- a/source/ios_kernel/source/kernel_patches.c
+++ b/source/ios_kernel/source/kernel_patches.c
@@ -56,11 +56,11 @@ ThreadContext_t **currentThreadContext = (ThreadContext_t **) 0x08173ba0;
 uint32_t *domainAccessPermissions      = (uint32_t *) 0x081a4000;
 
 int kernel_syscall_0x81(u32 command, u32 arg1, u32 arg2, u32 arg3) {
-    void (*invalidate_icache)()                           = (void (*)()) 0x0812DCF0;
-    void (*invalidate_dcache)(unsigned int, unsigned int) = (void (*)()) 0x08120164;
-    void (*flush_dcache)(unsigned int, unsigned int)      = (void (*)()) 0x08120160;
-    int result                                            = 0;
-    int level                                             = disable_interrupts();
+    void (*invalidate_icache)() = (void (*)()) 0x0812DCF0;
+    //void (*invalidate_dcache)(unsigned int, unsigned int) = (void (*)()) 0x08120164;
+    void (*flush_dcache)(unsigned int, unsigned int) = (void (*)()) 0x08120160;
+    int result                                       = 0;
+    int level                                        = disable_interrupts();
     set_domain_register(domainAccessPermissions[0]); // 0 = KERNEL
 
     switch (command) {

--- a/source/ios_kernel/source/kernel_patches.c
+++ b/source/ios_kernel/source/kernel_patches.c
@@ -69,7 +69,7 @@ int kernel_syscall_0x81(u32 command, u32 arg1, u32 arg2, u32 arg3) {
             break;
         }
         case KERNEL_WRITE32: {
-            *(volatile u32 *) arg1 = arg2;
+            kernel_memcpy((void*)arg1, &arg2, sizeof(uint32_t));
             flush_dcache(arg1, 4);
             invalidate_icache();
             break;

--- a/source/ios_kernel/source/main.c
+++ b/source/ios_kernel/source/main.c
@@ -30,8 +30,6 @@
 #define USB_PHYS_CODE_BASE 0x101312D0
 #define FS_PHYS_CODE_BASE  0x107F8200
 
-static u32 stroopwafel = 1;
-
 typedef struct {
     u32 size;
     u8 data[0];
@@ -63,7 +61,7 @@ static const char repairData_usb_root_thread[] = {
 };
 // clang-format on
 
-int _main() {
+int _main(u32 stroopwafel) {
     void (*invalidate_icache)()                           = (void (*)()) 0x0812DCF0;
     void (*invalidate_dcache)(unsigned int, unsigned int) = (void (*)()) 0x08120164;
     void (*flush_dcache)(unsigned int, unsigned int)      = (void (*)()) 0x08120160;

--- a/source/ios_kernel/source/main.c
+++ b/source/ios_kernel/source/main.c
@@ -30,6 +30,8 @@
 #define USB_PHYS_CODE_BASE 0x101312D0
 #define FS_PHYS_CODE_BASE  0x107F8200
 
+static u32 stroopwafel = 1;
+
 typedef struct {
     u32 size;
     u8 data[0];
@@ -79,29 +81,31 @@ int _main() {
     *(volatile uint32_t *) 0x0812c138 = 0xe3a00000; // mov r0, #0
     *(volatile uint32_t *) 0x0812c13c = 0xe12fff1e; // bx lr
 
-    void *pset_fault_behavior = (void *) 0x081298BC;
-    kernel_memcpy(pset_fault_behavior, (void *) repairData_set_fault_behavior, sizeof(repairData_set_fault_behavior));
+    if(!stroopwafel){
+        void *pset_fault_behavior = (void *) 0x081298BC;
+        kernel_memcpy(pset_fault_behavior, (void *) repairData_set_fault_behavior, sizeof(repairData_set_fault_behavior));
 
-    void *pset_panic_behavior = (void *) 0x081296E4;
-    kernel_memcpy(pset_panic_behavior, (void *) repairData_set_panic_behavior, sizeof(repairData_set_panic_behavior));
+        void *pset_panic_behavior = (void *) 0x081296E4;
+        kernel_memcpy(pset_panic_behavior, (void *) repairData_set_panic_behavior, sizeof(repairData_set_panic_behavior));
 
-    void *pusb_root_thread = (void *) 0x10100174;
-    kernel_memcpy(pusb_root_thread, (void *) repairData_usb_root_thread, sizeof(repairData_usb_root_thread));
+        void *pusb_root_thread = (void *) 0x10100174;
+        kernel_memcpy(pusb_root_thread, (void *) repairData_usb_root_thread, sizeof(repairData_usb_root_thread));
 
-    payload_info_t *payloads = (payload_info_t *) 0x00148000;
-    kernel_memcpy((void *) USB_PHYS_CODE_BASE, payloads->data, payloads->size);
+        payload_info_t *payloads = (payload_info_t *) 0x00148000;
+        kernel_memcpy((void *) USB_PHYS_CODE_BASE, payloads->data, payloads->size);
 
-    payloads = (payload_info_t *) 0x00149000;
-    kernel_memcpy((void *) net_get_phys_code_base(), payloads->data, payloads->size);
+        payloads = (payload_info_t *) 0x00149000;
+        kernel_memcpy((void *) net_get_phys_code_base(), payloads->data, payloads->size);
 
-    payloads = (payload_info_t *) 0x00160000;
-    kernel_memcpy((void *) mcp_get_phys_code_base(), payloads->data, payloads->size);
+        payloads = (payload_info_t *) 0x00160000;
+        kernel_memcpy((void *) mcp_get_phys_code_base(), payloads->data, payloads->size);
 
-    payloads = (payload_info_t *) 0x00170000;
-    kernel_memcpy((void *) FS_PHYS_CODE_BASE, payloads->data, payloads->size);
+        payloads = (payload_info_t *) 0x00170000;
+        kernel_memcpy((void *) FS_PHYS_CODE_BASE, payloads->data, payloads->size);
+    }
 
     // run all instant patches as necessary
-    instant_patches_setup();
+    instant_patches_setup(stroopwafel);
 
     *(volatile u32 *) (0x1555500) = 0;
 

--- a/source/ios_kernel/source/main.c
+++ b/source/ios_kernel/source/main.c
@@ -79,7 +79,7 @@ int _main(u32 stroopwafel) {
     *(volatile uint32_t *) 0x0812c138 = 0xe3a00000; // mov r0, #0
     *(volatile uint32_t *) 0x0812c13c = 0xe12fff1e; // bx lr
 
-    if(!stroopwafel){
+    if (!stroopwafel) {
         void *pset_fault_behavior = (void *) 0x081298BC;
         kernel_memcpy(pset_fault_behavior, (void *) repairData_set_fault_behavior, sizeof(repairData_set_fault_behavior));
 

--- a/source/ios_kernel/source/utils.c
+++ b/source/ios_kernel/source/utils.c
@@ -88,8 +88,7 @@ void reverse_memcpy(void *dst, const void *src, unsigned int size) {
 void *memset(void *dst, int val, size_t size) {
     char *_dst = dst;
 
-    int i;
-    for (i = 0; i < size; i++)
+    for (size_t i = 0; i < size; i++)
         _dst[i] = val;
 
     return dst;

--- a/source/ios_mcp/source/mcp_loadfile.c
+++ b/source/ios_mcp/source/mcp_loadfile.c
@@ -23,6 +23,7 @@
 #include "ipc_types.h"
 #include "logger.h"
 #include "svc.h"
+#include <inttypes.h>
 #include <mocha/commands.h>
 #include <stdio.h>
 #include <string.h>
@@ -181,7 +182,7 @@ MCP_LoadCustomFile(LoadTargetDevice target, char *path, uint32_t filesize, uint3
 
     int bytesRead = 0;
     int result    = MCP_DoLoadFile(filepath, NULL, buffer_out, buffer_len, pos + fileoffset, &bytesRead, 0);
-    DEBUG_FUNCTION_LINE("MCP_DoLoadFile returned %d, bytesRead = %d pos %u\n", result, bytesRead, pos + fileoffset);
+    DEBUG_FUNCTION_LINE("MCP_DoLoadFile returned %d, bytesRead = %d pos %lu\n", result, bytesRead, pos + fileoffset);
 
     if (result >= 0) {
         if (bytesRead <= 0) {
@@ -246,7 +247,7 @@ bool isCurrentHomebrewWrapperReplacement(MCPLoadFileRequest *request) {
     return false;
 }
 
-const RPXFileReplacements *GetCurrentRPXReplacementEx(MCPLoadFileRequest *request, const RPXFileReplacements **list, uint32_t list_size, int *offset) {
+const RPXFileReplacements *GetCurrentRPXReplacementEx(MCPLoadFileRequest *request, const RPXFileReplacements **list, uint32_t list_size, uint32_t *offset) {
     if (!offset || *offset >= list_size) {
         return NULL;
     }
@@ -336,7 +337,7 @@ static uint32_t getReplacementDataInSingleArray(const RPXFileReplacements **tmpA
     return offsetInResult;
 }
 
-const RPXFileReplacements *GetCurrentRPXReplacement(MCPLoadFileRequest *request, int *offset) {
+const RPXFileReplacements *GetCurrentRPXReplacement(MCPLoadFileRequest *request, uint32_t *offset) {
     const RPXFileReplacements *tmpArray[TEMP_ARRAY_SIZE] = {};
     uint32_t elementsInArray                             = getReplacementDataInSingleArray(tmpArray, TEMP_ARRAY_SIZE);
     if (elementsInArray == 0) {
@@ -385,7 +386,7 @@ int MCPLoadFileReplacement(ipcmessage *msg, MCPLoadFileRequest *request) {
     }
 
     // Try any fitting rpx replacement
-    int offset                                = 0;
+    uint32_t offset                           = 0;
     const RPXFileReplacements *curReplacement = NULL;
     do {
         // the offset is used as input AND output.
@@ -606,7 +607,7 @@ int _MCP_ioctl100_patch(ipcmessage *msg) {
                         return 22;
                     }
 
-                    DEBUG_FUNCTION_LINE("Will load %s for next title from target: %d (offset %u, filesize %u)\n",
+                    DEBUG_FUNCTION_LINE("Will load %s for next title from target: %d (offset %lu, filesize %lu)\n",
                                         newReplacement->replacementPath, target, fileoffset, filesize);
                     return 0;
                 } else {

--- a/source/ios_net/source/main.c
+++ b/source/ios_net/source/main.c
@@ -37,6 +37,6 @@ uint32_t DLP_FSA_OpenFile(int fd, char *path, char *mode, uint32_t *outhandle) {
 uint32_t DLP_GetChildTitleId(uint32_t *titleId, uint32_t uniqueId, int fsaHandle, const char *path, uint8_t childIndex) {
     int (*const real_DLP_GetChildTitleId)(uint32_t * titleId, uint32_t uniqueId, int fsaHandle, const char *, uint8_t childIndex) = (void *) 0x1239bd38;
     int result                                                                                                                    = real_DLP_GetChildTitleId(titleId, uniqueId, fsaHandle, path, childIndex);
-    printf("DLP_GetChildTitleId(%08X%08X unique %08X handle %08X path \"%s\" childindex %02X) returned %d \n", titleId[0], titleId[1], uniqueId, fsaHandle, path, childIndex, result);
+    printf("DLP_GetChildTitleId(%08lX%08lX unique %08lX handle %08X path \"%s\" childindex %02X) returned %d \n", titleId[0], titleId[1], uniqueId, fsaHandle, path, childIndex, result);
     return result;
 }

--- a/source/main.cpp
+++ b/source/main.cpp
@@ -7,6 +7,7 @@
 #include <cstdio>
 #include <cstring>
 #include <mocha/commands.h>
+#include <stroopwafel/stroopwafel.h>
 #include <sysapp/title.h>
 
 static void StartMCPThreadIfMochaAlreadyRunning() {
@@ -36,6 +37,8 @@ int main(int argc, char **argv) {
 
     StartMCPThreadIfMochaAlreadyRunning();
 
+    Stroopwafel_InitLibrary();
+
     ExecuteIOSExploit();
 
     // When the kernel exploit is set up successfully, we signal the ios to move on.
@@ -50,5 +53,8 @@ int main(int argc, char **argv) {
         IOS_Ioctl(mcpFd, 100, &in, sizeof(in), &out, sizeof(out));
         IOS_Close(mcpFd);
     }
+
+    Stroopwafel_DeInitLibrary();
+
     return 0;
 }

--- a/source/main.cpp
+++ b/source/main.cpp
@@ -53,7 +53,5 @@ int main(int argc, char **argv) {
         IOS_Close(mcpFd);
     }
 
-    Stroopwafel_DeInitLibrary();
-
     return 0;
 }

--- a/source/main.cpp
+++ b/source/main.cpp
@@ -37,7 +37,6 @@ int main(int argc, char **argv) {
 
     StartMCPThreadIfMochaAlreadyRunning();
 
-    Stroopwafel_InitLibrary();
 
     ExecuteIOSExploit();
 


### PR DESCRIPTION
When stroopwafel is used, we already have complete control over IOSU. In that case running the IOS exploit is unnecessary and a potential point for failure.

This PR adds functionality to use the new stroopwafel IPC interface through `libstroopwafel`.
It uses stroopwafel to:
- map more memory into MCP
- copy the mocha payloads to IOSU
- execute the kernel payload

The kernel payload was modified slightly to account for stroopwafel having already copied the payloads to their final location and the additional sections for MCP are already mapped.
I also made a PoC branch which works with a unmodified payload: https://github.com/jan-hofmeier/MochaPayload/tree/stroopwafel_kern_only but I would prefer the full stroopwafel solution, since it avoids the intermediate copies to magic memory solutions.

Please don't merge just yet, but I would appreciate feedback on this