### PR TITLE
remove usb payload from stroopwafel path

### DIFF
--- a/source/ios_exploit.c
+++ b/source/ios_exploit.c
@@ -402,13 +402,11 @@ static int use_stroopwafel() {
     if (res != STROOPWAFEL_RESULT_SUCCESS)
         return res;
 
+    // The USB payload just inculdes repair logic, so we can omit it here
     StroopwafelWrite payload_infos[] = {
             {.dest_addr = ARM_CODE_BASE,
              .src       = ios_kernel,
              .length    = sizeof(ios_kernel)},
-            {.dest_addr = 0x101312D0,
-             .src       = ios_usb,
-             .length    = sizeof(ios_usb)},
             {.dest_addr = 0x12431900,
              .src       = ios_net,
              .length    = sizeof(ios_net)},


### PR DESCRIPTION
it's only needed to repair exploit damage